### PR TITLE
일반 / 정기구독 장바구니 분리, 장바구니 할인 적용

### DIFF
--- a/server/src/main/java/server/team33/cart/controller/CartController.java
+++ b/server/src/main/java/server/team33/cart/controller/CartController.java
@@ -1,0 +1,44 @@
+package server.team33.cart.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import server.team33.cart.entity.Cart;
+import server.team33.cart.entity.ItemCart;
+import server.team33.cart.mapper.CartMapper;
+import server.team33.cart.mapper.ItemCartMapper;
+import server.team33.cart.service.CartService;
+import server.team33.cart.service.ItemCartService;
+import server.team33.item.mapper.ItemMapper;
+import server.team33.response.SingleResponseDto;
+
+import javax.validation.constraints.Positive;
+
+@Slf4j
+@Validated
+@CrossOrigin
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/carts")
+public class CartController {
+
+    private final CartService cartService;
+    private final CartMapper cartMapper;
+    private final ItemCartService itemCartService;
+    private final ItemMapper itemMapper;
+    private final ItemCartMapper itemCartMapper;
+
+    @GetMapping("/{cart-id}")
+    public ResponseEntity getCart(@PathVariable("cart-id") @Positive long cartId,
+                                       @RequestParam(value="subscription", defaultValue="false") boolean subscription) {
+
+        Cart cart = cartService.findCart(cartId);
+
+        return new ResponseEntity<>(new SingleResponseDto<>(cartMapper.cartToCartResponseDto(
+                        cart, cartService, subscription, itemCartService, itemMapper, itemCartMapper)), HttpStatus.OK);
+    }
+
+}

--- a/server/src/main/java/server/team33/cart/controller/ItemCartController.java
+++ b/server/src/main/java/server/team33/cart/controller/ItemCartController.java
@@ -7,13 +7,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import server.team33.cart.dto.ItemCartDto;
-import server.team33.cart.entity.Cart;
 import server.team33.cart.entity.ItemCart;
 import server.team33.cart.mapper.ItemCartMapper;
 import server.team33.cart.service.CartService;
 import server.team33.cart.service.ItemCartService;
+import server.team33.item.mapper.ItemMapper;
 import server.team33.item.service.ItemService;
-import server.team33.response.MultiResponseDto;
 import server.team33.response.SingleResponseDto;
 import server.team33.user.mapper.UserMapper;
 import server.team33.user.service.UserService;
@@ -31,10 +30,10 @@ public class ItemCartController {
 
     private final ItemCartService itemCartService;
     private final ItemCartMapper itemCartMapper;
+    private final ItemMapper itemMapper;
     private final ItemService itemService;
     private final CartService cartService;
     private final UserService userService;
-    private final UserMapper userMapper;
 
     @PostMapping("/{item-id}")
     public ResponseEntity postItemCart(@Valid @RequestBody ItemCartDto.Post itemCartPostDto,
@@ -44,25 +43,34 @@ public class ItemCartController {
                 itemCartPostDtoToItemCart(itemId, userService, itemService, itemCartPostDto));
 
         return new ResponseEntity<>(
-                new SingleResponseDto<>(itemCartMapper), HttpStatus.CREATED);
+                new SingleResponseDto<>(itemCartMapper.itemCartToItemCartResponseDto(
+                        itemMapper, itemCart)), HttpStatus.CREATED);
     }
 
-    @GetMapping("/{cart-id}")
-    public void getItemCarts(@PathVariable("cart-id") @Positive long cartId,
-                                       @RequestParam(value="subscription", defaultValue="false") boolean subscription) {
-        Cart cart = cartService.findCart(cartId);
-        itemCartService.findItemCarts(cart, subscription);
-        // TODO : responseDtos mapper 구현
-//        return new ResponseEntity<>(new MultiResponseDto<>(itemCartMapper.itemCartsToItemCartResponseDtos()), HttpStatus.OK);
+    @PatchMapping("/itemcarts/{itemcart-id}")
+    public ResponseEntity upDownItemCart(@PathVariable("itemcart-id") @Positive long itemCartId,
+                                          @RequestParam(value="upDown") int upDown) {
+        ItemCart itemCart = itemCartService.findItemCart(itemCartId);
+        ItemCart upDownItemCart = itemCartService.updateItemCart(itemCart, upDown);
+        cartService.refreshCart(upDownItemCart.getCart().getCartId(), upDownItemCart.isSubscription());
 
+        return new ResponseEntity<>(
+                new SingleResponseDto<>(itemCartMapper.itemCartToItemCartResponseDto(
+                        itemMapper, upDownItemCart)), HttpStatus.CREATED);
     }
 
-    @DeleteMapping("/{cart-id}/itemCarts/{itemCart-id}")
+    @DeleteMapping("/{cart-id}/itemCarts") // 장바구니에서 특정 아이템 삭제
     public ResponseEntity deleteItemCart(@PathVariable("cart-id") @Positive long cartId,
-                                         @PathVariable("itemCart-id") @Positive long itemCartId) {
-        // TODO : 본인 확인 후 삭제 권한 부여
+                                         @RequestParam("itemCart-id") @Positive long itemCartId) {
         itemCartService.deleteItemCart(itemCartId);
 
         return new ResponseEntity(HttpStatus.NO_CONTENT);
     }
+
+//    @DeleteMapping("/order/{order-id}")
+//    public ResponseEntity emptyItemCart(@PathVariable("order-id") @Positive long orderId) {
+//
+//        return new ResponseEntity(HttpStatus.NO_CONTENT);
+//    }
+//    TODO : orderDto 를 body 로 받아서 로직 구현
 }

--- a/server/src/main/java/server/team33/cart/dto/CartResponseDto.java
+++ b/server/src/main/java/server/team33/cart/dto/CartResponseDto.java
@@ -1,0 +1,23 @@
+package server.team33.cart.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import server.team33.response.MultiResponseDto;
+
+import javax.validation.constraints.Positive;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CartResponseDto {
+
+    @Positive
+    private Long cartId;
+    private boolean subscription;
+    private MultiResponseDto<ItemCartDto.Response> itemCartResponses;
+    private int totalItems;
+    private int totalPrice;
+    private int totalDiscountPrice;
+    private int expectPrice; // 결제 예상 금액 (totalPrice - totalDiscountPrice)
+}

--- a/server/src/main/java/server/team33/cart/entity/Cart.java
+++ b/server/src/main/java/server/team33/cart/entity/Cart.java
@@ -1,9 +1,6 @@
 package server.team33.cart.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import server.team33.audit.Auditable;
 import server.team33.user.entity.User;
 
@@ -16,17 +13,35 @@ import java.util.List;
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
-public class Cart extends Auditable {
+public class Cart {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long cartId;
 
-    @Column(nullable = false)
-    private Integer totalItems = 0;
+    @Column
+    @Setter
+    private Integer totalItems;
 
-    @Column(nullable = false)
-    private Integer totalPrice = 0;
+    @Column
+    @Setter
+    private Integer totalPrice;
+
+    @Column
+    @Setter
+    private Integer totalDiscountPrice;
+
+    @Column
+    @Setter
+    private Integer subTotalItems;
+
+    @Column
+    @Setter
+    private Integer subTotalPrice;
+
+    @Column
+    @Setter
+    private Integer subTotalDiscountPrice;
 
     @OneToOne
     private User user;

--- a/server/src/main/java/server/team33/cart/mapper/CartMapper.java
+++ b/server/src/main/java/server/team33/cart/mapper/CartMapper.java
@@ -1,0 +1,46 @@
+package server.team33.cart.mapper;
+
+import org.mapstruct.Mapper;
+import server.team33.cart.dto.CartResponseDto;
+import server.team33.cart.entity.Cart;
+import server.team33.cart.entity.ItemCart;
+import server.team33.cart.service.CartService;
+import server.team33.cart.service.ItemCartService;
+import server.team33.item.mapper.ItemMapper;
+import server.team33.response.MultiResponseDto;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface CartMapper {
+
+    default CartResponseDto cartToCartResponseDto(Cart cart, CartService cartService,
+                                                  boolean subscription,
+                                                  ItemCartService itemCartService,
+                                                  ItemMapper itemMapper,
+                                                  ItemCartMapper itemCartMapper) {
+        CartResponseDto cartResponseDto = new CartResponseDto();
+        cartResponseDto.setCartId(cart.getCartId());
+        cartResponseDto.setSubscription(subscription);
+
+        List<ItemCart> itemCarts = itemCartService.findItemCarts(cart, subscription);
+
+        itemCartMapper.itemCartsToItemCartResponseDtos(itemMapper, itemCarts);
+        cartResponseDto.setItemCartResponses(new MultiResponseDto<>(
+                itemCartMapper.itemCartsToItemCartResponseDtos(itemMapper, itemCarts)));
+
+        if(subscription) {
+            cartResponseDto.setTotalPrice(cart.getSubTotalPrice());
+            cartResponseDto.setTotalItems(cart.getSubTotalItems());
+
+        } else {
+            cartResponseDto.setTotalPrice(cart.getTotalPrice());
+            cartResponseDto.setTotalItems(cart.getTotalItems());
+        }
+
+        cartResponseDto.setTotalDiscountPrice(cartService.countTotalDiscountPrice(cart.getCartId(), subscription));
+        cartResponseDto.setExpectPrice(cartResponseDto.getTotalPrice() - cartResponseDto.getTotalDiscountPrice());
+
+        return cartResponseDto;
+    }
+}

--- a/server/src/main/java/server/team33/cart/mapper/ItemCartMapper.java
+++ b/server/src/main/java/server/team33/cart/mapper/ItemCartMapper.java
@@ -8,6 +8,9 @@ import server.team33.item.service.ItemService;
 import server.team33.user.entity.User;
 import server.team33.user.service.UserService;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Mapper(componentModel = "spring")
 public interface ItemCartMapper {
 
@@ -20,9 +23,10 @@ public interface ItemCartMapper {
                 .period(itemCartPostDto.getPeriod())
                 .buyNow(itemCartPostDto.isBuyNow())
                 .subscription(itemCartPostDto.isSubscription())
+//                .cart(user.getCart())
                 .item(itemService.findItem(itemId))
                 .build();
-        // TODO : 카트 정보 추가, 주문 정보 추가
+        // TODO : 유저 정보 추가
     }
 
     default ItemCartDto.Response itemCartToItemCartResponseDto(ItemMapper itemMapper, ItemCart itemCart) {
@@ -33,7 +37,21 @@ public interface ItemCartMapper {
                 .buyNow(itemCart.isBuyNow())
                 .subscription(itemCart.isSubscription())
 //                .item(itemMapper.itemToItemResponseDto(itemCart.getItem()))
+                .createdAt(itemCart.getCreatedAt())
+                .updatedAt(itemCart.getUpdatedAt())
                 .build();
-        // TODO : 생성 시간, 업데이트 시간 추가
+        // TODO : 간소화된 itemResponseDto 적용 필요
+    }
+
+    default List<ItemCartDto.Response> itemCartsToItemCartResponseDtos(ItemMapper itemMapper, List<ItemCart> itemCarts) {
+        if(itemCarts == null) return null;
+
+        List<ItemCartDto.Response> itemCartResponseDtos = new ArrayList<>(itemCarts.size());
+
+        for(ItemCart itemCart : itemCarts) {
+            itemCartResponseDtos.add(itemCartToItemCartResponseDto(itemMapper, itemCart));
+        }
+
+        return itemCartResponseDtos;
     }
 }

--- a/server/src/main/java/server/team33/cart/repository/ItemCartRepository.java
+++ b/server/src/main/java/server/team33/cart/repository/ItemCartRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface ItemCartRepository extends JpaRepository<ItemCart, Long> {
 
-    ItemCart findByCartAndItem(Cart cart, Item item);
+    ItemCart findByCartAndItemAndSubscription(Cart cart, Item item, boolean subscription);
 
     List<ItemCart> findAllByCartAndSubscription(Cart cart, boolean subscription);
 

--- a/server/src/main/java/server/team33/cart/service/ItemCartService.java
+++ b/server/src/main/java/server/team33/cart/service/ItemCartService.java
@@ -36,7 +36,8 @@ public class ItemCartService {
     }
 
     public ItemCart checkItemCart(ItemCart itemCart) { // 장바구니에 특정 아이템이 이미 담겨있는지 확인
-        return itemCartRepository.findByCartAndItem(itemCart.getCart(), itemCart.getItem());
+        return itemCartRepository.findByCartAndItemAndSubscription(
+                itemCart.getCart(), itemCart.getItem(), itemCart.isSubscription());
     }
 
     public ItemCart findItemCart(long itemCartId) {

--- a/server/src/main/java/server/team33/response/MultiResponseDto.java
+++ b/server/src/main/java/server/team33/response/MultiResponseDto.java
@@ -22,4 +22,8 @@ public class MultiResponseDto<T> {
                 page.getTotalElements(),
                 page.getTotalPages());
     }
+
+    public MultiResponseDto(List<T> data) {
+        this.data = data;
+    }
 }


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #17 #16 

<br>

## 무엇이 추가 되었나요?
- 일반 장바구니와 정기구독 장바구니를 각각 불러올 수 있도록 컨트롤러를 구현했습니다.
- 장바구니에서 각각의 아이템마다 할인을 적용하여 총금액, 할인된 금액, 결제예정금액을 불러올 수 있도록 했습니다.

<br>

## 기타 정보

<br>
