### PR TITLE
[Client] 태그 버튼 컴포넌트 UI 구현 

### DIFF
--- a/client/src/components/Buttons/TagButton.js
+++ b/client/src/components/Buttons/TagButton.js
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+function FuncTag({ funcArr }) {
+	return (
+		<TagBox>
+			{funcArr.map((func, index) => (
+				<button type="button" key={`${index.toString()}-${func}`}>
+					{func}
+				</button>
+			))}
+		</TagBox>
+	);
+}
+
+const TagBox = styled.div`
+	display: inline-flex;
+	& > button {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		font-size: 13px;
+		font-weight: var(--bold);
+		height: 23px;
+		cursor: pointer;
+		color: var(--purple-300);
+		border: none;
+		background-color: #efecff;
+		border-radius: 6px;
+		margin-right: 6px;
+		padding: 0 6px;
+	}
+`;
+
+export default FuncTag;


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #19 

<br>

## 무엇이 추가 되었나요?
<img width="696" alt="스크린샷 2022-11-20 오전 12 21 08" src="https://user-images.githubusercontent.com/105625895/202858286-760ffecc-854e-4092-91a5-300f461f0e6b.png">

태그 버튼을 추가했습니다. 배열을 받아서 map을 이용해 버튼을 만듭니다. 긴 문자열로 기능들이 들어오면 이걸 배열로 만들어서 뿌려주면 될 것 같아요.
<br>

## 기타 정보

<br>
