### PR TITLE
[Client] 배경색 path별로 분기 설정 및 마이페이지 Header 구현

### DIFF
--- a/client/src/components/Buttons/LetterButton.js
+++ b/client/src/components/Buttons/LetterButton.js
@@ -18,7 +18,13 @@ export function LetterButton({ children, width, height, onClick }) {
 	);
 }
 
-export function GrayLetterButton({ children, width, height, onClick }) {
+export function GrayLetterButton({
+	children,
+	width,
+	height,
+	onClick,
+	fontSize = '11px',
+}) {
 	return (
 		<DefaultButton
 			onClick={onClick}
@@ -28,7 +34,7 @@ export function GrayLetterButton({ children, width, height, onClick }) {
 			height={height}
 			hoverColor="gray"
 			hoverColorCode="400"
-			fontSize="11px"
+			fontSize={fontSize}
 			letter
 		>
 			{children}

--- a/client/src/components/Etc/MyPageHeader.js
+++ b/client/src/components/Etc/MyPageHeader.js
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+import { TempLogo } from '../../assets/Icons';
+import { GrayLetterButton } from '../Buttons/LetterButton';
+
+function MyPageHeader({ nickname }) {
+	return (
+		<Container>
+			<TempLogo />
+			<TextContainer>
+				<Nickname>{nickname || '타락파워전사'}</Nickname>
+				<Nim>님</Nim>
+				<GrayLetterButton fontSize="13px">로그아웃</GrayLetterButton>
+			</TextContainer>
+		</Container>
+	);
+}
+
+const Container = styled.header`
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	svg {
+		width: 43px;
+		height: 20px;
+	}
+`;
+
+const TextContainer = styled.div`
+	display: flex;
+	align-items: flex-end;
+	border-bottom: 1px solid var(--gray-200);
+	padding: 15px 0 30px 0;
+`;
+
+const Nim = styled.div`
+	color: var(--gray-400);
+	font-size: 36px;
+	font-weight: var(--bold);
+	margin-left: 7px;
+	margin-right: 25px;
+`;
+
+const Nickname = styled.h1`
+	font-size: 36px;
+	font-weight: var(--extraBold);
+	color: var(--gray-600);
+`;
+
+export default MyPageHeader;

--- a/client/src/components/Etc/MyPageHeader.js
+++ b/client/src/components/Etc/MyPageHeader.js
@@ -28,7 +28,6 @@ const Container = styled.header`
 const TextContainer = styled.div`
 	display: flex;
 	align-items: flex-end;
-	border-bottom: 1px solid var(--gray-200);
 	padding: 15px 0 30px 0;
 `;
 

--- a/client/src/components/Etc/PageTitle.js
+++ b/client/src/components/Etc/PageTitle.js
@@ -13,7 +13,8 @@ function PageTitle({ title }) {
 const Container = styled.div`
 	display: flex;
 	flex-direction: column;
-
+	width: 100%;
+	border-bottom: 1px solid var(--gray-200);
 	svg {
 		width: 43px;
 		height: 20px;
@@ -25,7 +26,6 @@ const Title = styled.h1`
 	font-size: 36px;
 	font-weight: var(--extraBold);
 	padding: 15px 0 30px 0;
-	border-bottom: 1px solid var(--gray-200);
 `;
 
 export default PageTitle;

--- a/client/src/components/Layout/Layout.js
+++ b/client/src/components/Layout/Layout.js
@@ -9,8 +9,10 @@ const hideURL = ['/login', '/signup'];
 function Layout() {
 	const { pathname } = useLocation();
 	const hide = hideURL.includes(pathname);
+	const firstPathname = pathname.split('/')[1];
+
 	return (
-		<Container>
+		<Container pathname={firstPathname}>
 			<TopContainer>
 				{hide || <LeftNav />}
 				<MainContainer className={hide ? 'noMargin' : null}>
@@ -31,6 +33,26 @@ const Container = styled.div`
 	justify-content: space-between;
 	min-width: fit-content;
 	min-height: 100vh;
+	${({ pathname }) => {
+		switch (pathname) {
+			case 'cart':
+			case 'pay':
+				return `
+				background-color: var(--gray-100)
+				`;
+			case 'mypage':
+				return `
+				background-image: linear-gradient(to bottom, white 278px, var(--gray-100) 0)
+				`;
+			case '':
+				return `
+				background-image: linear-gradient(to bottom, white 800px, var(--gray-100) 0)
+				`;
+			default:
+				return `
+				background-color: white`;
+		}
+	}}
 `;
 
 const TopContainer = styled.div`
@@ -44,7 +66,8 @@ const MainContainer = styled.div`
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	margin: 120px 0 180px 0;
+	margin-top: 120px;
+	padding-bottom: 180px;
 	max-width: 1240px;
 	width: 100%;
 	&.noMargin {

--- a/client/src/pages/MyPage.js
+++ b/client/src/pages/MyPage.js
@@ -1,16 +1,25 @@
 // 마이페이지
 // 여기로오면 mypage/user로 보내세요
 import { Outlet } from 'react-router-dom';
+import styled from 'styled-components';
 import MypageTab from '../components/Tabs/MypageTab';
+import MyPageHeader from '../components/Etc/MyPageHeader';
 
 function MyPage() {
 	return (
-		<>
+		<Container>
+			<MyPageHeader />
 			<MypageTab />
-			<h1>MyPage/</h1>
 			<Outlet />
-		</>
+		</Container>
 	);
 }
+
+const Container = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	width: 100%;
+`;
 
 export default MyPage;


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #75

<br>

## 무엇이 추가 되었나요?

- 마이페이지에 공통적으로 들어가는 헤더를 제작하였습니다.
  - 헤더에는 사용자 닉네임과 로그아웃 버튼이 포함되어 있습니다.
- [LetterButton.js/GrayLetterButton](https://github.com/codestates-seb/seb40_main_033/commit/8b4c62f746644cd4de20fcfee16c1c9dd47f5301)의 props에 `fontSize`를 추가하여, 글자 크기를 변경할 수 있도록 하였습니다.
- 배경색을 path별로 분기 설정하였습니다.

<br>

## 기타 정보

<img width="1423" alt="스크린샷 2022-11-23 오전 10 04 50" src="https://user-images.githubusercontent.com/107875909/203451049-130aaddf-0133-4d5e-9f5e-3246c209e8cb.png">


<br>
