### PR TITLE
[Server] 장바구니 일부 및 전체 목록 주문 기능 구현

### DIFF
--- a/server/src/main/java/server/team33/cart/controller/CartController.java
+++ b/server/src/main/java/server/team33/cart/controller/CartController.java
@@ -31,11 +31,10 @@ public class CartController {
     private final ItemMapper itemMapper;
     private final ItemCartMapper itemCartMapper;
 
-    @GetMapping("/{cart-id}")
-    public ResponseEntity getCart(@PathVariable("cart-id") @Positive long cartId,
-                                       @RequestParam(value="subscription", defaultValue="false") boolean subscription) {
+    @GetMapping
+    public ResponseEntity getCart(@RequestParam(value="subscription", defaultValue="false") boolean subscription) {
 
-        Cart cart = cartService.findCart(cartId);
+        Cart cart = cartService.findMyCart();
 
         return new ResponseEntity<>(new SingleResponseDto<>(cartMapper.cartToCartResponseDto(
                         cart, cartService, subscription, itemCartService, itemMapper, itemCartMapper)), HttpStatus.OK);

--- a/server/src/main/java/server/team33/cart/dto/CartResponseDto.java
+++ b/server/src/main/java/server/team33/cart/dto/CartResponseDto.java
@@ -15,7 +15,7 @@ public class CartResponseDto {
     @Positive
     private Long cartId;
     private boolean subscription;
-    private MultiResponseDto<ItemCartDto.Response> itemCartResponses;
+    private MultiResponseDto<ItemCartDto.Response> itemCarts;
     private int totalItems;
     private int totalPrice;
     private int totalDiscountPrice;

--- a/server/src/main/java/server/team33/cart/dto/ItemCartDto.java
+++ b/server/src/main/java/server/team33/cart/dto/ItemCartDto.java
@@ -19,7 +19,7 @@ public class ItemCartDto {
         private Integer quantity;
 
         private Integer period;
-        private boolean buyNow;
+//        private boolean buyNow; 장바구니에 담을 경우 디폴트 == 장바구니에서 선택된 상태
         private boolean subscription;
     }
 

--- a/server/src/main/java/server/team33/cart/entity/Cart.java
+++ b/server/src/main/java/server/team33/cart/entity/Cart.java
@@ -63,6 +63,7 @@ public class Cart {
     public static Cart createCart(User user) {
         Cart cart = new Cart();
         cart.user = user;
+        user.setCart(cart);
         return cart;
     }
 }

--- a/server/src/main/java/server/team33/cart/entity/ItemCart.java
+++ b/server/src/main/java/server/team33/cart/entity/ItemCart.java
@@ -1,9 +1,6 @@
 package server.team33.cart.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 import server.team33.audit.Auditable;
@@ -13,6 +10,7 @@ import server.team33.item.entity.Item;
 import javax.persistence.*;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/server/src/main/java/server/team33/cart/mapper/CartMapper.java
+++ b/server/src/main/java/server/team33/cart/mapper/CartMapper.java
@@ -21,19 +21,19 @@ public interface CartMapper {
         cartResponseDto.setCartId(cart.getCartId());
         cartResponseDto.setSubscription(subscription);
 
-        List<ItemCart> itemCarts = itemCartService.findItemCarts(cart, subscription);
+        List<ItemCart> itemCarts = itemCartService.findItemCarts(cart, subscription); // 목록은 체크 + 언체크 모두 조회
 
         itemCartMapper.itemCartsToItemCartResponseDtos(itemMapper, itemCarts);
-        cartResponseDto.setItemCartResponses(new MultiResponseDto<>(
+        cartResponseDto.setItemCarts(new MultiResponseDto<>(
                 itemCartMapper.itemCartsToItemCartResponseDtos(itemMapper, itemCarts)));
 
         if(subscription) {
-            cartResponseDto.setTotalPrice(cart.getSubTotalPrice());
-            cartResponseDto.setTotalItems(cart.getSubTotalItems());
+            cartResponseDto.setTotalPrice(cart.getSubTotalPrice() == null ? 0 : cart.getSubTotalPrice());
+            cartResponseDto.setTotalItems(cart.getSubTotalItems() == null ? 0 : cart.getSubTotalItems());
 
         } else {
-            cartResponseDto.setTotalPrice(cart.getTotalPrice());
-            cartResponseDto.setTotalItems(cart.getTotalItems());
+            cartResponseDto.setTotalPrice(cart.getTotalPrice() == null ? 0 : cart.getTotalPrice());
+            cartResponseDto.setTotalItems(cart.getTotalItems() == null ? 0 : cart.getTotalItems());
         }
 
         cartResponseDto.setTotalDiscountPrice(cartService.countTotalDiscountPrice(cart.getCartId(), subscription));

--- a/server/src/main/java/server/team33/cart/mapper/ItemCartMapper.java
+++ b/server/src/main/java/server/team33/cart/mapper/ItemCartMapper.java
@@ -20,8 +20,8 @@ public interface ItemCartMapper {
         User user = userService.getLoginUser();
         return ItemCart.builder()
                 .quantity(itemCartPostDto.getQuantity())
-                .period(itemCartPostDto.getPeriod())
-                .buyNow(itemCartPostDto.isBuyNow())
+                .period(itemCartPostDto.getPeriod() == null ? 0 : itemCartPostDto.getPeriod())
+                .buyNow(true)
                 .subscription(itemCartPostDto.isSubscription())
                 .cart(user.getCart())
                 .item(itemService.findVerifiedItem(itemId))

--- a/server/src/main/java/server/team33/cart/repository/ItemCartRepository.java
+++ b/server/src/main/java/server/team33/cart/repository/ItemCartRepository.java
@@ -13,5 +13,7 @@ public interface ItemCartRepository extends JpaRepository<ItemCart, Long> {
 
     List<ItemCart> findAllByCartAndSubscription(Cart cart, boolean subscription);
 
+    List<ItemCart> findAllByCartAndSubscriptionAndBuyNow(Cart cart, boolean subscription, boolean buyNow);
+
     void deleteByItemAndCart(Item item, Cart cart); // 주문시 장바구니에서 아이템 삭제
 }

--- a/server/src/main/java/server/team33/cart/service/CartService.java
+++ b/server/src/main/java/server/team33/cart/service/CartService.java
@@ -8,6 +8,8 @@ import server.team33.cart.entity.ItemCart;
 import server.team33.cart.repository.CartRepository;
 import server.team33.exception.bussiness.BusinessLogicException;
 import server.team33.exception.bussiness.ExceptionCode;
+import server.team33.user.entity.User;
+import server.team33.user.service.UserService;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,6 +21,7 @@ public class CartService {
 
     private final CartRepository cartRepository;
     private final ItemCartService itemCartService;
+    private final UserService userService;
 
     public void refreshCart(long cartId, boolean subscription) { // 가격과 아이템 종류 갱신
         Cart cart = findVerifiedCart(cartId);
@@ -32,6 +35,11 @@ public class CartService {
         }
 
         cartRepository.save(cart);
+    }
+
+    public Cart findMyCart() {
+        User user = userService.getLoginUser();
+        return cartRepository.findByUser(user);
     }
 
     public Cart findCart(long cartId) {
@@ -48,7 +56,7 @@ public class CartService {
 
     public int countTotalDiscountPrice(long cartId, boolean subscription) {
         Cart cart = findVerifiedCart(cartId);
-        List<ItemCart> itemCarts = itemCartService.findItemCarts(cart, subscription);
+        List<ItemCart> itemCarts = itemCartService.findItemCarts(cart, subscription, true);
 
         if(itemCarts == null) return 0;
 
@@ -67,7 +75,7 @@ public class CartService {
 
     private int countTotalPrice(long cartId, boolean subscription) {
         Cart cart = findVerifiedCart(cartId);
-        List<ItemCart> itemCarts = itemCartService.findItemCarts(cart, subscription);
+        List<ItemCart> itemCarts = itemCartService.findItemCarts(cart, subscription, true);
 
         if(itemCarts == null) return 0;
 
@@ -84,6 +92,6 @@ public class CartService {
 
     private int countTotalItems(long cartId, boolean subscription) {
         Cart cart = findVerifiedCart(cartId);
-        return itemCartService.findItemCarts(cart, subscription).size();
+        return itemCartService.findItemCarts(cart, subscription, true).size();
     }
 }

--- a/server/src/main/java/server/team33/cart/service/ItemCartService.java
+++ b/server/src/main/java/server/team33/cart/service/ItemCartService.java
@@ -45,21 +45,39 @@ public class ItemCartService {
         return findItemCart;
     }
 
-    public ItemCart updateItemCart(ItemCart itemCart, int upDown) { // 수량 변경( +1 or -1)
+    public ItemCart updownItemCart(long itemCartId, int upDown) { // 수량 변경( +1 or -1)
+        ItemCart itemCart = findVerifiedItemCart(itemCartId);
         itemCart.addQuantity(upDown);
         itemCartRepository.save(itemCart);
         return itemCart;
     }
 
-    public void deleteItemCart(long itemCartId) {
+    public ItemCart periodItemCart(long itemCartId, int period) { // 정기 구독 주기 변경
+        ItemCart itemCart = findVerifiedItemCart(itemCartId);
+        itemCart.setPeriod(period);
+        return itemCartRepository.save(itemCart);
+    }
+
+    public ItemCart excludeItemCart(long itemCartId, boolean buyNow) { // 아이템 체크 및 해제
+        ItemCart itemCart = findVerifiedItemCart(itemCartId);
+        itemCart.setBuyNow(buyNow);
+        return itemCartRepository.save(itemCart);
+    }
+
+    public void deleteItemCart(long itemCartId) { // 장바구니 항목 삭제
         ItemCart itemCart = findVerifiedItemCart(itemCartId);
         itemCartRepository.delete(itemCart);
     }
 
-    public List<ItemCart> findItemCarts(Cart cart, boolean subscription) {
+    public List<ItemCart> findItemCarts(Cart cart, boolean subscription) { // 장바구니 목록 조회
         return itemCartRepository.findAllByCartAndSubscription(cart, subscription);
-        // isSubscription == true 정기구독 장바구니 목록 조회
-        // isSubscription == false 일반 장바구니 목록 조회
+        // subscription - true 정기구독, false 일반
+    }
+
+    public List<ItemCart> findItemCarts(Cart cart, boolean subscription, boolean buyNow) { // 금액 합계, 주문
+        return itemCartRepository.findAllByCartAndSubscriptionAndBuyNow(cart, subscription, buyNow);
+        // subscription - true 정기구독, false 일반
+        // buyNow - true 체크박스 활성화, false 체크박스 비활성화
     }
 
     public ItemCart findVerifiedItemCart(long itemCartId) {

--- a/server/src/main/java/server/team33/item/entity/Item.java
+++ b/server/src/main/java/server/team33/item/entity/Item.java
@@ -48,6 +48,9 @@ public class Item {
     private int discountRate;
 
     @Column
+    private int view;
+
+    @Column
     private int sales;
 
     @Column

--- a/server/src/main/java/server/team33/item/mapper/ItemMapper.java
+++ b/server/src/main/java/server/team33/item/mapper/ItemMapper.java
@@ -48,6 +48,7 @@ public interface ItemMapper {
         item.setDiscountRate(post.getDiscountRate());
         item.setCapacity(post.getCapacity());
         item.setPrice(post.getPrice());
+        item.setView(0);
         item.setSales(post.getSales());
         item.setTitle(post.getTitle());
         item.setContent(post.getContent());

--- a/server/src/main/java/server/team33/item/repository/ItemRepository.java
+++ b/server/src/main/java/server/team33/item/repository/ItemRepository.java
@@ -26,4 +26,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 //    @Query()
 //    List<Item> find9BestItemAnd9SaleItem();
 
+    @Query("SELECT i FROM Item i join Category c on i.itemId = c.item.itemId WHERE c.categoryName  = :categoryName AND i.discountPrice > 0")
+    Page<Item> findAllCategoryNameSaleItem(Pageable pageable, @Param("categoryName") String categoryName);
+
 }

--- a/server/src/main/java/server/team33/item/service/ItemService.java
+++ b/server/src/main/java/server/team33/item/service/ItemService.java
@@ -27,6 +27,7 @@ public class ItemService {
     // 아이템 상세페이지 조회 비지니스 로직
     public Item findItem(long itemId) {
         Item item = findVerifiedItem(itemId);
+        item.setView(item.getView()+1);
         return itemRepository.save(item);
     }
 

--- a/server/src/main/java/server/team33/order/mapper/ItemOrderMapper.java
+++ b/server/src/main/java/server/team33/order/mapper/ItemOrderMapper.java
@@ -1,6 +1,8 @@
 package server.team33.order.mapper;
 
 import org.mapstruct.Mapper;
+import server.team33.cart.entity.ItemCart;
+import server.team33.cart.service.ItemCartService;
 import server.team33.item.entity.Item;
 import server.team33.item.mapper.ItemMapper;
 import server.team33.item.service.ItemService;
@@ -25,6 +27,30 @@ public interface ItemOrderMapper {
         itemOrder.setItem(item);
 
         return itemOrder;
+    }
+
+    default ItemOrder itemCartToItemOrder(ItemCart itemCart) { // 장바구니를 불러와서 주문으로 변환
+        ItemOrder itemOrder = new ItemOrder();
+        itemOrder.setQuantity(itemCart.getQuantity());
+        itemOrder.setPeriod(itemCart.getPeriod());
+        itemOrder.setSubscription(itemCart.isSubscription());
+        itemOrder.setItem(itemCart.getItem());
+
+        return itemOrder;
+    }
+
+    default List<ItemOrder> itemCartsToItemOrders(List<ItemCart> itemCarts, ItemCartService itemCartService) {
+
+        if(itemCarts == null) return null;
+
+        List<ItemOrder> itemOrders = new ArrayList<>();
+
+        for(ItemCart itemCart : itemCarts) {
+            itemOrders.add(itemCartToItemOrder(itemCart));
+            itemCartService.deleteItemCart(itemCart.getItemCartId());
+        }
+
+        return itemOrders;
     }
 
     default ItemOrderDto.SimpleResponse itemOrderToItemOrderSimpleResponseDto(

--- a/server/src/main/java/server/team33/order/service/ItemOrderService.java
+++ b/server/src/main/java/server/team33/order/service/ItemOrderService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import server.team33.order.entity.ItemOrder;
 import server.team33.order.reposiroty.ItemOrderRepository;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -15,8 +16,12 @@ public class ItemOrderService {
 
     private final ItemOrderRepository itemOrderRepository;
 
-    public ItemOrder createItemOrder(ItemOrder itemOrder) {
-        return itemOrderRepository.save(itemOrder);
+    public List<ItemOrder> createItemOrder(ItemOrder itemOrder) {
+        itemOrderRepository.save(itemOrder);
+        List<ItemOrder> itemOrders = new ArrayList<>();
+        itemOrders.add(itemOrder);
+
+        return itemOrders;
     }
 
     public int countTotalPrice(List<ItemOrder> itemOrders) {

--- a/server/src/main/java/server/team33/user/service/UserService.java
+++ b/server/src/main/java/server/team33/user/service/UserService.java
@@ -10,6 +10,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.team33.cart.entity.Cart;
+import server.team33.cart.repository.CartRepository;
 import server.team33.exception.bussiness.BusinessLogicException;
 import server.team33.exception.bussiness.ExceptionCode;
 import server.team33.login.jwt.JwtToken;
@@ -37,12 +38,14 @@ public class UserService {
     private final AuthUtils authUtils;
     private final JwtToken jwtToken;
     private final UserInfoFilter userInfoFilter;
+    private final CartRepository cartRepository;
 
     public User joinUser( User user ){
         userInfoFilter.filterUserInfo(user);
         encodePassword(user);
         createRole(user);
-        Cart.createCart(user);
+        Cart cart = Cart.createCart(user);
+        cartRepository.save(cart);
         userRepository.save(user);
         return user;
     }


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #79 #78 #3 

<br>

## 무엇이 추가 되었나요?
- 장바구니 로직을 전반적으로 리팩토링 했습니다.
- 장바구니에서 특정 항목만 선택해서 구매할 수 있고, 전체 목록을 구매할 수도 있습니다.
- 아이템의 조회수 기능을 구현 했습니다.

<br>

## 기타 정보
- 장바구니 항목의 수량 변경 기능 추가
- 장바구니에서 정기 구독 상품의 구독 주기 변경 기능 추가
- 장바구니 항목 선택/선택 해제 기능 추가
- 장바구니 내 선택한 항목의 수량 및 가격 집계 기능 추가
- 장바구니에서 상품을 주문할 경우, 해당 상품은 장바구니에서 삭제되는 기능 추가
<br>
