### PR TITLE
[Server] 아이템 판매량 집계, 아이템의 리뷰 및 토크 목록 불러오기

### DIFF
--- a/server/src/main/java/server/team33/item/controller/ItemController.java
+++ b/server/src/main/java/server/team33/item/controller/ItemController.java
@@ -11,6 +11,10 @@ import server.team33.item.entity.Item;
 import server.team33.item.mapper.ItemMapper;
 import server.team33.item.service.ItemService;
 import server.team33.response.SingleResponseDto;
+import server.team33.review.mapper.ReviewMapper;
+import server.team33.review.service.ReviewService;
+import server.team33.talk.mapper.TalkMapper;
+import server.team33.talk.service.TalkService;
 
 
 @Slf4j
@@ -23,6 +27,11 @@ public class ItemController {
     private final ItemService itemService;
     private final ItemMapper mapper;
 
+    private final ReviewService reviewService;
+    private final ReviewMapper reviewMapper;
+    private final TalkService talkService;
+    private final TalkMapper talkMapper;
+
     @PostMapping
     public ResponseEntity postItem(@RequestBody ItemDto.post post) { // 아이템 등록을 위한 컨트롤러
         Item item = mapper.itemPostDtoToItem(post);
@@ -32,9 +41,12 @@ public class ItemController {
     }
 
     @GetMapping("/{item-id}")
-    public ResponseEntity getItem(@PathVariable("item-id") long itemId) {
+    public ResponseEntity getItem(@PathVariable("item-id") long itemId,
+                                  @RequestParam(value="reviewPage", defaultValue="1") int reviewPage,
+                                  @RequestParam(value="talkPage", defaultValue="1") int talkPage) {
         Item item = itemService.findItem(itemId);
-        return new ResponseEntity(new SingleResponseDto<>(mapper.itemToItemDetailResponseDto(item)), HttpStatus.OK);
+        return new ResponseEntity(new SingleResponseDto<>(mapper.itemToItemDetailResponseDto(
+                item, reviewService, reviewMapper, talkService, talkMapper, reviewPage-1, 3, talkPage-1, 2)), HttpStatus.OK);
     }
 
 //    @GetMapping("/main")

--- a/server/src/main/java/server/team33/item/dto/ItemDto.java
+++ b/server/src/main/java/server/team33/item/dto/ItemDto.java
@@ -6,8 +6,9 @@ import lombok.Setter;
 import server.team33.category.dto.CategoryDto;
 import server.team33.item.entity.Brand;
 import server.team33.nutritionFact.entity.NutritionFact;
-import server.team33.review.entity.Review;
-import server.team33.talk.entity.Talk;
+import server.team33.response.MultiResponseDto;
+import server.team33.review.dto.ReviewResponseDto;
+import server.team33.talk.dto.TalkAndCommentDto;
 
 import java.util.List;
 
@@ -35,8 +36,8 @@ public class ItemDto {
         // wish 관련되어 추가될 예정
         private List<NutritionFact> nutritionFacts;
         private double starAvg;
-        private List<Review> reviews;
-        private List<Talk> talks;
+//        private List<Review> reviews;
+//        private List<Talk> talks;
     }
 
     @Getter
@@ -59,8 +60,8 @@ public class ItemDto {
         private List<CategoryDto.Response> categories;
         private List<NutritionFact> nutritionFacts;
         private double starAvg;
-        private List<Review> reviews;
-        private List<Talk> talks;
+        private MultiResponseDto<ReviewResponseDto> reviews;
+        private MultiResponseDto<TalkAndCommentDto> talks;
     }
 
 

--- a/server/src/main/java/server/team33/item/mapper/ItemMapper.java
+++ b/server/src/main/java/server/team33/item/mapper/ItemMapper.java
@@ -1,11 +1,19 @@
 package server.team33.item.mapper;
 
 import org.mapstruct.Mapper;
+import org.springframework.data.domain.Page;
 import server.team33.category.dto.CategoryDto;
 import server.team33.category.entity.Category;
 import server.team33.item.dto.ItemDto;
 import server.team33.item.dto.ItemSimpleResponseDto;
 import server.team33.item.entity.Item;
+import server.team33.response.MultiResponseDto;
+import server.team33.review.entity.Review;
+import server.team33.review.mapper.ReviewMapper;
+import server.team33.review.service.ReviewService;
+import server.team33.talk.entity.Talk;
+import server.team33.talk.mapper.TalkMapper;
+import server.team33.talk.service.TalkService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,8 +41,41 @@ public interface ItemMapper {
         itemDetailResponseDto.setNutritionFacts(item.getNutritionFacts());
         itemDetailResponseDto.setCategories(categoryToCategoryResponseDto(item.getCategories()));
         itemDetailResponseDto.setStarAvg(item.getStarAvg());
-        itemDetailResponseDto.setReviews(item.getReviews());
-        itemDetailResponseDto.setTalks(item.getTalks());
+//        itemDetailResponseDto.setReviews(item.getReviews());
+//        itemDetailResponseDto.setTalks(item.getTalks());
+
+        return itemDetailResponseDto;
+    }
+
+    default ItemDto.ItemDetailResponse itemToItemDetailResponseDto(Item item, ReviewService reviewService, ReviewMapper reviewMapper,
+                                                                   TalkService talkService, TalkMapper talkMapper,
+                                                                   int reviewPage, int reviewSize, int talkPage, int talkSize) { // 아이템 상세 조회
+
+        ItemDto.ItemDetailResponse itemDetailResponseDto = new ItemDto.ItemDetailResponse();
+
+        itemDetailResponseDto.setItemId(item.getItemId());
+        itemDetailResponseDto.setThumbnail(item.getThumbnail());
+        itemDetailResponseDto.setTitle(item.getTitle());
+        itemDetailResponseDto.setContent(item.getContent());
+        itemDetailResponseDto.setExpiration(item.getExpiration());
+        itemDetailResponseDto.setBrand(item.getBrand());
+        itemDetailResponseDto.setSales(item.getSales());
+        itemDetailResponseDto.setPrice(item.getPrice());
+        itemDetailResponseDto.setCapacity(item.getCapacity());
+        itemDetailResponseDto.setServingSize(item.getServingSize());
+        itemDetailResponseDto.setDiscountRate(item.getDiscountRate());
+        itemDetailResponseDto.setDiscountPrice(item.getDiscountPrice());
+        itemDetailResponseDto.setNutritionFacts(item.getNutritionFacts());
+        itemDetailResponseDto.setCategories(categoryToCategoryResponseDto(item.getCategories()));
+        itemDetailResponseDto.setStarAvg(item.getStarAvg());
+
+        Page<Review> pageReview = reviewService.findItemReviews(item, reviewPage, reviewSize);
+        List<Review> reviews = pageReview.getContent();
+        itemDetailResponseDto.setReviews(new MultiResponseDto<>(reviewMapper.reviewsToReviewResponseDtos(reviews), pageReview));
+
+        Page<Talk> pageTalk = talkService.findItemTalks(item, talkPage, talkSize);
+        List<Talk> talks = pageTalk.getContent();
+        itemDetailResponseDto.setTalks(new MultiResponseDto<>(talkMapper.talksToTalkAndCommentDtos(talks), pageTalk));
 
         return itemDetailResponseDto;
     }
@@ -59,8 +100,8 @@ public interface ItemMapper {
         item.setServingSize(post.getServingSize());
         item.setNutritionFacts(post.getNutritionFacts());
         item.setStarAvg(post.getStarAvg());
-        item.setReviews(post.getReviews());
-        item.setTalks(post.getTalks());
+//        item.setReviews(post.getReviews());
+//        item.setTalks(post.getTalks());
 
         return item;
     }

--- a/server/src/main/java/server/team33/order/dto/OrderDto.java
+++ b/server/src/main/java/server/team33/order/dto/OrderDto.java
@@ -16,6 +16,7 @@ public class OrderDto {
         private long orderId;
         private String name;
         private String address;
+        private String detailAddress;
         private String phone;
     }
 
@@ -44,6 +45,7 @@ public class OrderDto {
         private long orderId;
         private String name;
         private String address;
+        private String detailAddress;
         private String phone;
         private int totalItems;
         private int totalPrice;

--- a/server/src/main/java/server/team33/order/entity/Order.java
+++ b/server/src/main/java/server/team33/order/entity/Order.java
@@ -25,6 +25,9 @@ public class Order extends Auditable {
     @Column(nullable = false)
     private String address;
 
+    @Column
+    private String detailAddress;
+
     @Column(nullable = false)
     private String phone;
 

--- a/server/src/main/java/server/team33/order/mapper/OrderMapper.java
+++ b/server/src/main/java/server/team33/order/mapper/OrderMapper.java
@@ -68,6 +68,7 @@ public interface OrderMapper {
         orderDetailResponseDto.setOrderId(order.getOrderId());
         orderDetailResponseDto.setName(order.getName());
         orderDetailResponseDto.setAddress(order.getAddress());
+        orderDetailResponseDto.setDetailAddress(order.getDetailAddress());
         orderDetailResponseDto.setPhone(order.getPhone());
         orderDetailResponseDto.setTotalItems(order.getTotalItems());
         orderDetailResponseDto.setTotalPrice(order.getTotalPrice());

--- a/server/src/main/java/server/team33/order/service/ItemOrderService.java
+++ b/server/src/main/java/server/team33/order/service/ItemOrderService.java
@@ -3,6 +3,7 @@ package server.team33.order.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import server.team33.item.repository.ItemRepository;
 import server.team33.order.entity.ItemOrder;
 import server.team33.order.reposiroty.ItemOrderRepository;
 
@@ -16,6 +17,7 @@ import java.util.List;
 public class ItemOrderService {
 
     private final ItemOrderRepository itemOrderRepository;
+    private final ItemRepository itemRepository;
 
     public List<ItemOrder> createItemOrder(ItemOrder itemOrder) {
         itemOrderRepository.save(itemOrder);
@@ -68,6 +70,22 @@ public class ItemOrderService {
         }
 
         return totalquantity;
+    }
+
+    public void minusSales(List<ItemOrder> itemOrders) { // 주문 취소할 경우 아이템 판매량에서 제외
+
+        for(ItemOrder itemOrder : itemOrders) {
+            int sales = itemOrder.getQuantity();
+            itemOrder.getItem().setSales(itemOrder.getItem().getSales() - sales);
+            itemRepository.save(itemOrder.getItem());
+        }
+    }
+
+    public void plusSales(ItemOrder itemOrder) { // 주문 요청할 경우 아이템 판매량 증가
+
+        int sales = itemOrder.getQuantity();
+        itemOrder.getItem().setSales(itemOrder.getItem().getSales() + sales);
+        itemRepository.save(itemOrder.getItem());
     }
 
     public void changePeriod( ItemOrder itemOrder, Integer period ){

--- a/server/src/main/java/server/team33/order/service/OrderService.java
+++ b/server/src/main/java/server/team33/order/service/OrderService.java
@@ -32,6 +32,7 @@ public class OrderService {
         order.setItemOrders(itemOrders);
         order.setName(user.getName());
         order.setAddress(user.getAddress());
+        order.setDetailAddress(user.getDetailAddress());
         order.setPhone(user.getPhone());
         order.setSubscription(itemOrders.get(0).isSubscription());
         order.setTotalItems(itemOrders.size());
@@ -44,6 +45,7 @@ public class OrderService {
 
         for(ItemOrder itemOrder : itemOrders) {
             itemOrder.setOrder(order);
+            itemOrderService.plusSales(itemOrder); // 판매량 누적
             itemOrderRepository.save(itemOrder);
         }
 
@@ -59,6 +61,7 @@ public class OrderService {
     public void cancelOrder(long orderId) {
         Order findOrder = findOrder(orderId);
         findOrder.setOrderStatus(OrderStatus.ORDER_CANCEL);
+        itemOrderService.minusSales(findOrder.getItemOrders()); // 주문 취소 -> 판매량 집계에서 제외
         orderRepository.save(findOrder);
     }
 

--- a/server/src/main/java/server/team33/review/repository/ReviewRepository.java
+++ b/server/src/main/java/server/team33/review/repository/ReviewRepository.java
@@ -8,14 +8,13 @@ import server.team33.item.entity.Item;
 import server.team33.review.entity.Review;
 import server.team33.user.entity.User;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     Page<Review> findAllByUser(Pageable pageable, User user); // 마이페이지에서 유저가 작성한 리뷰 목록을 불러옴
 
-    List<Review> findAllByItem(Item item); // 아이템상세페이지에서 아이템의 리뷰 목록을 불러옴
+    Page<Review> findAllByItem(Pageable pageable, Item item); // 아이템상세페이지에서 아이템의 리뷰 목록을 불러옴
 
     @Query("SELECT avg(r.star) from Review r where r.item.itemId = :itemId") // 아이템의 리뷰 평점
     Optional<Double> findReviewAvg(long itemId);

--- a/server/src/main/java/server/team33/review/service/ReviewService.java
+++ b/server/src/main/java/server/team33/review/service/ReviewService.java
@@ -46,6 +46,14 @@ public class ReviewService {
         return pageReviews;
     }
 
+    public Page<Review> findItemReviews(Item item, int page, int size) {
+
+        Page<Review> pageReview = reviewRepository.findAllByItem(
+                PageRequest.of(page, size, Sort.by("reviewId").descending()), item);
+
+        return pageReview;
+    }
+
     public long findReviewWriter(long reviewId) { // 작성자만 수정, 삭제를 할 수 있도록 리뷰의 작성자 찾기
         Review review = findVerifiedReview(reviewId);
         return review.getUser().getUserId();

--- a/server/src/main/java/server/team33/talk/mapper/TalkMapper.java
+++ b/server/src/main/java/server/team33/talk/mapper/TalkMapper.java
@@ -18,7 +18,6 @@ import server.team33.user.entity.User;
 import server.team33.user.service.UserService;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @Mapper(componentModel = "spring")
@@ -79,6 +78,35 @@ public interface TalkMapper {
         }
 
         return talkResponseDtos;
+    }
+
+    default TalkAndCommentDto talkToTalkAndCommentDto(Talk talk) {
+
+        TalkAndCommentDto talkAndCommentDto = new TalkAndCommentDto();
+        talkAndCommentDto.setTalkId(talk.getTalkId());
+        talkAndCommentDto.setUserId(talk.getUser().getUserId());
+        talkAndCommentDto.setItemId(talk.getItem().getItemId());
+        talkAndCommentDto.setContent(talk.getContent());
+        talkAndCommentDto.setShopper(talk.isShopper());
+        talkAndCommentDto.setCreatedAt(talk.getCreatedAt());
+        talkAndCommentDto.setUpdatedAt(talk.getUpdatedAt());
+
+        List<TalkCommentDto> talkCommentDtos = talkCommentsToTalkCommentDtos(talk.getTalkComments());
+        talkAndCommentDto.setTalkComments(talkCommentDtos);
+
+        return talkAndCommentDto;
+    }
+
+    default List<TalkAndCommentDto> talksToTalkAndCommentDtos(List<Talk> talks) {
+
+        if(talks == null) return null;
+
+        List<TalkAndCommentDto> talkAndCommentDtos = new ArrayList<>();
+
+        for(Talk talk : talks) {
+            talkAndCommentDtos.add(talkToTalkAndCommentDto(talk));
+        }
+        return talkAndCommentDtos;
     }
 
     default TalkDetailResponseDto talkToTalkDetailResponseDto(Talk talk, ItemMapper itemMapper) {
@@ -149,6 +177,19 @@ public interface TalkMapper {
         commentDto.setUpdatedAt(talkComment.getUpdatedAt());
 
         return commentDto;
+    }
+
+    default List<TalkCommentDto> talkCommentsToTalkCommentDtos(List<TalkComment> talkComments) {
+
+        if(talkComments == null) return null;
+
+        List<TalkCommentDto> talkCommentDtos = new ArrayList<>();
+
+        for(TalkComment talkComment : talkComments) {
+            talkCommentDtos.add(talkCommentToTalkCommentDto(talkComment));
+        }
+
+        return talkCommentDtos;
     }
 
     default TalkOrCommentDto toTalkOrCommentDto(Talk talk, ItemMapper itemMapper) { // 마이페이지 - 토크 조회

--- a/server/src/main/java/server/team33/talk/repository/TalkRepository.java
+++ b/server/src/main/java/server/team33/talk/repository/TalkRepository.java
@@ -1,6 +1,9 @@
 package server.team33.talk.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import server.team33.item.entity.Item;
 import server.team33.talk.entity.Talk;
 import server.team33.user.entity.User;
 
@@ -9,4 +12,6 @@ import java.util.List;
 public interface TalkRepository extends JpaRepository<Talk, Long> {
 
     List<Talk> findAllByUser(User user);
+
+    Page<Talk> findAllByItem(Pageable pageable, Item item);
 }

--- a/server/src/main/java/server/team33/talk/service/TalkService.java
+++ b/server/src/main/java/server/team33/talk/service/TalkService.java
@@ -1,10 +1,14 @@
 package server.team33.talk.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import server.team33.exception.bussiness.BusinessLogicException;
 import server.team33.exception.bussiness.ExceptionCode;
+import server.team33.item.entity.Item;
 import server.team33.item.repository.ItemRepository;
 import server.team33.item.service.ItemService;
 import server.team33.talk.entity.Talk;
@@ -19,8 +23,6 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class TalkService {
 
-    private final ItemService itemService;
-    private final ItemRepository itemRepository;
     private final TalkRepository talkRepository;
 
     public Talk createTalk(Talk talk) { // 토크 작성 - 상세페이지
@@ -45,6 +47,13 @@ public class TalkService {
         List<Talk> talksByUser = talkRepository.findAllByUser(user);
 
         return talksByUser;
+    }
+
+    public Page<Talk> findItemTalks(Item item, int page, int size) {
+        Page<Talk> pageTalk = talkRepository.findAllByItem(
+                PageRequest.of(page, size, Sort.by("talkId").descending()), item);
+
+        return pageTalk;
     }
 
     public void deleteTalk(long talkId, long userId) { // 토크 삭제 - 작성자만 가능


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #88 #95 

<br>

## 무엇이 추가 되었나요?
- 주문 정보에 유저의 상세 주소 추가
- 아이템 판매량 집계
- 아이템 상세페이지에서 해당 아이템에 관한 리뷰 목록과 토크 목록 조회

<br>

## 기타 정보

<br>
