### PR TITLE
[Server] 아이템 키워드검색 결과 필터링 중첩 적용

### DIFF
--- a/server/src/main/java/server/team33/item/controller/ItemController.java
+++ b/server/src/main/java/server/team33/item/controller/ItemController.java
@@ -89,5 +89,25 @@ public class ItemController {
         return new ResponseEntity(new MultiResponseDto<>(mapper.itemsToItemCategoryResponseDto(itemList), itemPage), HttpStatus.OK);
     }
 
+    @GetMapping("/search/sale")
+    public ResponseEntity searchSaleItems(@RequestParam("keyword") String keyword,
+                                          @Positive @RequestParam(value = "page", defaultValue = "1") int page,
+                                          @Positive @RequestParam(value = "size", defaultValue = "16") int size,
+                                          @RequestParam(value = "sort", defaultValue = "sales") String sort) { // 키워드 검색 + 세일
+        Page<Item> itemPage = itemService.searchSaleItems(keyword, page-1, size, sort);
+        List<Item> itemList = itemPage.getContent();
+        return new ResponseEntity<>(new MultiResponseDto<>(mapper.itemsToItemCategoryResponseDto(itemList), itemPage), HttpStatus.OK);
+    }
+
+    @GetMapping("/search/sale/price")
+    public ResponseEntity searchSalePriceFilteredItems(@RequestParam("keyword") String keyword, @RequestParam("low") int low, @RequestParam("high") int high,
+                                                       @Positive @RequestParam(value = "page", defaultValue = "1") int page,
+                                                       @Positive @RequestParam(value = "size", defaultValue = "16") int size,
+                                                       @RequestParam(value = "sort", defaultValue = "sales") String sort) { // 키워드 검색 + 세일 + 가격 필터
+        Page<Item> itemPage = itemService.searchSalePriceFilteredItems(keyword, low, high, page-1, size, sort);
+        List<Item> itemList = itemPage.getContent();
+        return new ResponseEntity<>(new MultiResponseDto<>(mapper.itemsToItemCategoryResponseDto(itemList), itemPage), HttpStatus.OK);
+    }
+
 }
 

--- a/server/src/main/java/server/team33/item/dto/ItemDto.java
+++ b/server/src/main/java/server/team33/item/dto/ItemDto.java
@@ -6,7 +6,6 @@ import lombok.Setter;
 import server.team33.category.dto.CategoryDto;
 import server.team33.item.entity.Brand;
 import server.team33.nutritionFact.dto.NutritionFactDto;
-import server.team33.nutritionFact.entity.NutritionFact;
 import server.team33.response.MultiResponseDto;
 import server.team33.review.dto.ReviewResponseDto;
 import server.team33.talk.dto.TalkAndCommentDto;
@@ -69,17 +68,17 @@ public class ItemDto {
     @Getter
     @Setter
     @NoArgsConstructor
-    public static class ItemCategoryResponse {
+    public static class ItemCategoryResponse { // 목록 조회
         private Long itemId;
         private String thumbnail;
         private String title;
         private String content;
+        private int capacity;
         private int price;
-        private Brand brand;
-        private List<NutritionFact> nutritionFacts;
-        // 리뷰 총 별점
-        //item 의 찜의 여부
+        private double starAvg;
         private int reviewSize;
+        private Brand brand;
+        private List<NutritionFactDto.Response> nutritionFacts;
     }
 
     @Getter

--- a/server/src/main/java/server/team33/item/mapper/ItemMapper.java
+++ b/server/src/main/java/server/team33/item/mapper/ItemMapper.java
@@ -157,14 +157,15 @@ public interface ItemMapper {
         ItemDto.ItemCategoryResponse itemCategoryResponse = new ItemDto.ItemCategoryResponse();
 
         itemCategoryResponse.setItemId(item.getItemId());
+        itemCategoryResponse.setThumbnail(item.getThumbnail());
         itemCategoryResponse.setTitle(item.getTitle());
         itemCategoryResponse.setContent(item.getContent());
-        itemCategoryResponse.setBrand(item.getBrand());
+        itemCategoryResponse.setCapacity(item.getCapacity());
         itemCategoryResponse.setPrice(item.getPrice());
-        itemCategoryResponse.setNutritionFacts(item.getNutritionFacts());
-        // 리뷰 별 총점
-        // 찜의 여부 가 추가 될 예정
+        itemCategoryResponse.setStarAvg(item.getStarAvg());
         itemCategoryResponse.setReviewSize(item.getReviews().size());
+        itemCategoryResponse.setBrand(item.getBrand());
+        itemCategoryResponse.setNutritionFacts(nutritionFactToNutritionFactResponseDto(item.getNutritionFacts()));
 
         return itemCategoryResponse;
     }

--- a/server/src/main/java/server/team33/item/repository/ItemRepository.java
+++ b/server/src/main/java/server/team33/item/repository/ItemRepository.java
@@ -44,4 +44,8 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 
     Page<Item> findByTitleContainingAndPriceBetween(Pageable pageable, String keyword, int low, int high);
 
+    Page<Item> findByTitleContainingAndDiscountRateGreaterThan(Pageable pageable, String keyword, int minRate);
+
+    Page<Item> findByTitleContainingAndDiscountRateGreaterThanAndPriceBetween(Pageable pageable, String keyword, int minRate, int low, int high);
+
 }

--- a/server/src/main/java/server/team33/item/service/ItemService.java
+++ b/server/src/main/java/server/team33/item/service/ItemService.java
@@ -90,9 +90,24 @@ public class ItemService {
 
     public Page<Item> searchPriceFilteredItems(String keyword, int low, int high, int page, int size, String sort) {
         Page<Item> itemPage = itemRepository.findByTitleContainingAndPriceBetween(
-                PageRequest.of(page, size, Sort.by(sort).descending()),keyword, low, high);
+                PageRequest.of(page, size, Sort.by(sort).descending()), keyword, low, high);
 
         return itemPage;
     }
+
+    public Page<Item> searchSaleItems(String keyword, int page, int size, String sort) {
+        Page<Item> itemPage = itemRepository.findByTitleContainingAndDiscountRateGreaterThan(
+                PageRequest.of(page, size, Sort.by(sort).descending()),keyword, 0);
+
+        return itemPage;
+    }
+
+    public Page<Item> searchSalePriceFilteredItems(String keyword, int low, int high, int page, int size, String sort) {
+        Page<Item> itemPage = itemRepository.findByTitleContainingAndDiscountRateGreaterThanAndPriceBetween(
+                PageRequest.of(page, size, Sort.by(sort).descending()), keyword, 0, low, high);
+
+        return itemPage;
+    }
+
 
 }


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #126 

<br>

## 무엇이 추가 되었나요?
- 아이템 키워드 검색 결과에 세일 항목 모아보기, 가격 필터링을 각각 혹은 동시에 적용할 수 있도록 했습니다.
<br>

## 기타 정보

<br>
