### PR TITLE
[Client] 회원가입/로그인 페이지 API 통신+useFetch 구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -24,6 +24,7 @@
         "react-router-dom": "^6.4.3",
         "react-scripts": "5.0.1",
         "react-slick": "^0.29.0",
+        "react-toastify": "^9.1.1",
         "slick-carousel": "^1.8.1",
         "styled-components": "^5.3.6",
         "web-vitals": "^2.1.4"
@@ -5818,6 +5819,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -14784,6 +14793,18 @@
         "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-toastify": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.1.tgz",
+      "integrity": "sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -21749,6 +21770,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -28039,6 +28065,14 @@
         "json2mq": "^0.2.0",
         "lodash.debounce": "^4.0.8",
         "resize-observer-polyfill": "^1.5.0"
+      }
+    },
+    "react-toastify": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.1.tgz",
+      "integrity": "sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==",
+      "requires": {
+        "clsx": "^1.1.1"
       }
     },
     "read-cache": {

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "react-router-dom": "^6.4.3",
     "react-scripts": "5.0.1",
     "react-slick": "^0.29.0",
+    "react-toastify": "^9.1.1",
     "slick-carousel": "^1.8.1",
     "styled-components": "^5.3.6",
     "web-vitals": "^2.1.4"

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -16,7 +16,7 @@ function App() {
 				<GlobalStyle />
 				<Router />
 			</Provider>
-			<ToastContainer position="top-center" theme="colored" />
+			<ToastContainer position="top-center" autoClose={3000} theme="colored" />
 			<ReactQueryDevtools />
 		</QueryClientProvider>
 	);

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,9 +1,11 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { Provider } from 'react-redux';
 import { ReactQueryDevtools } from 'react-query/devtools';
+import { ToastContainer } from 'react-toastify';
 import GlobalStyle from './assets/style/GlobalStyle';
 import Router from './Router';
 import store from './redux/store/store';
+import 'react-toastify/dist/ReactToastify.css';
 
 const queryClient = new QueryClient();
 
@@ -14,6 +16,7 @@ function App() {
 				<GlobalStyle />
 				<Router />
 			</Provider>
+			<ToastContainer position="top-center" theme="colored" />
 			<ReactQueryDevtools />
 		</QueryClientProvider>
 	);

--- a/client/src/apis/login.js
+++ b/client/src/apis/login.js
@@ -1,11 +1,6 @@
-/* eslint-disable no-promise-executor-return */
-import { useState } from 'react';
-import { useMutation } from 'react-query';
-import { useDispatch } from 'react-redux';
-import { login } from '../redux/slice/userSlice';
 import axiosInstance from '../utils/axiosInstance';
 
-const handleLogin = async ({ email, password }) => {
+export const fetchLogin = async ({ email, password }) => {
 	const { data } = await axiosInstance.post('/users/login', {
 		username: email,
 		password,
@@ -24,39 +19,3 @@ export const fetchUserInfos = async () => {
 
 	return data.data;
 };
-
-const ERROR_MESSAGE = {
-	Unauthorized: '아이디 또는 비밀번호를 다시 확인해주세요.',
-	Forbidden: '유효하지 않은 접근입니다.',
-};
-
-export default function useLogin() {
-	const dispatch = useDispatch();
-	const [errMsg, setErrMsg] = useState('');
-	const { mutate, isLoading, isSuccess, isError } = useMutation(
-		(form) => handleLogin(form),
-		// () =>
-		// 	new Promise(() => {
-		// 		return { accessToken: 'asdasd', refreshToken: 'sdfsdf' };
-		// 	}),
-		{
-			onSuccess: async (data, { email }) => {
-				dispatch(login({ accessToken: data.split(' ')[1], email }));
-			},
-			onError: async (data) => {
-				const { response } = data;
-				const { status, data: errorData } = response;
-
-				if (status === 401) {
-					setErrMsg(ERROR_MESSAGE.Unauthorized);
-				} else if (status === 403) {
-					setErrMsg(ERROR_MESSAGE.Forbidden);
-				} else {
-					setErrMsg(errorData.message);
-				}
-			},
-		},
-	);
-
-	return { mutate, isLoading, isSuccess, isError, errMsg };
-}

--- a/client/src/apis/login.js
+++ b/client/src/apis/login.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-promise-executor-return */
 import { useState } from 'react';
 import { useMutation } from 'react-query';
 import { useDispatch } from 'react-redux';
@@ -5,13 +6,13 @@ import { login } from '../redux/slice/userSlice';
 import axiosInstance from '../utils/axiosInstance';
 
 const handleLogin = async ({ email, password }) => {
-	const { headers } = await axiosInstance.post('/users/login', {
+	const { data } = await axiosInstance.post('/users/login', {
 		username: email,
 		password,
 	});
 	// const { authorization: accessToken, refresh: refreshToken } = headers;
-
 	// return { accessToken, refreshToken };
+	return data;
 };
 
 export const fetchUserInfos = async () => {
@@ -34,9 +35,13 @@ export default function useLogin() {
 	const [errMsg, setErrMsg] = useState('');
 	const { mutate, isLoading, isSuccess, isError } = useMutation(
 		(form) => handleLogin(form),
+		// () =>
+		// 	new Promise(() => {
+		// 		return { accessToken: 'asdasd', refreshToken: 'sdfsdf' };
+		// 	}),
 		{
-			onSuccess: async ({ accessToken, refreshToken }, { keepLoggedIn }) => {
-				dispatch(login({ accessToken, refreshToken, keepLoggedIn }));
+			onSuccess: async (data, { email }) => {
+				dispatch(login({ accessToken: data.split(' ')[1], email }));
 			},
 			onError: async (data) => {
 				const { response } = data;

--- a/client/src/apis/userApis.js
+++ b/client/src/apis/userApis.js
@@ -33,7 +33,7 @@ export const fetchLogIn = async ({ email, password }) => {
 };
 
 export const fetchUserInfos = async () => {
-	const { data } = (await axiosInstance.get)('/user', {
+	const { data } = await axiosInstance.get('/user', {
 		headers: {
 			tokenNeeded: true,
 		},

--- a/client/src/apis/userApis.js
+++ b/client/src/apis/userApis.js
@@ -1,10 +1,22 @@
 import axiosInstance from '../utils/axiosInstance';
 
-export const fetchSignUp = async ({ email, password, name }) => {
+export const fetchSignUp = async ({
+	닉네임,
+	주소,
+	상세주소,
+	이름,
+	전화번호,
+	이메일,
+	비밀번호,
+}) => {
 	const { data } = await axiosInstance.post('/users', {
-		username: email,
-		password,
-		name,
+		displayName: 닉네임,
+		address: 주소,
+		detailAddress: 상세주소,
+		realName: 이름,
+		phone: 전화번호,
+		email: 이메일,
+		password: 비밀번호,
 	});
 
 	return data;

--- a/client/src/apis/userApis.js
+++ b/client/src/apis/userApis.js
@@ -1,6 +1,16 @@
 import axiosInstance from '../utils/axiosInstance';
 
-export const fetchLogin = async ({ email, password }) => {
+export const fetchSignUp = async ({ email, password, name }) => {
+	const { data } = await axiosInstance.post('/users', {
+		username: email,
+		password,
+		name,
+	});
+
+	return data;
+};
+
+export const fetchLogIn = async ({ email, password }) => {
 	const { data } = await axiosInstance.post('/users/login', {
 		username: email,
 		password,
@@ -18,4 +28,14 @@ export const fetchUserInfos = async () => {
 	});
 
 	return data.data;
+};
+
+export const fetchLogOut = async () => {
+	const { data } = await axiosInstance.post('/users/logout', {
+		headers: {
+			tokenNeeded: true,
+		},
+	});
+
+	return data;
 };

--- a/client/src/components/Inputs/AuthForm.js
+++ b/client/src/components/Inputs/AuthForm.js
@@ -174,7 +174,7 @@ export function AuthForm({ signUp, mutate, handleLogIn }) {
 			console.log('signUp', data);
 			handleLogIn(data);
 		} else {
-			console.log({ email: data.이메일, password: data.비밀번호 });
+			console.log('signIn', data);
 			mutate({ email: data.이메일, password: data.비밀번호 });
 		}
 	};

--- a/client/src/components/Inputs/AuthForm.js
+++ b/client/src/components/Inputs/AuthForm.js
@@ -7,7 +7,7 @@ import AuthInput from './AuthInput';
 import { PurpleButton } from '../Buttons/PurpleButton';
 import AddressModal from '../Modals/AddressModal';
 
-export function AuthForm({ signUp, mutate, handleLogIn }) {
+export function AuthForm({ signUp, handleSignUp, handleLogIn }) {
 	const [current, setCurrent] = useState(1);
 	const [currentChange, setCurrentChange] = useState(false);
 	const [isModalOpen, setIsModalOpen] = useState(false);
@@ -172,10 +172,10 @@ export function AuthForm({ signUp, mutate, handleLogIn }) {
 	const onValid = (data) => {
 		if (signUp) {
 			console.log('signUp', data);
-			handleLogIn(data);
+			handleSignUp(data);
 		} else {
 			console.log('signIn', data);
-			mutate({ email: data.이메일, password: data.비밀번호 });
+			handleLogIn(data);
 		}
 	};
 

--- a/client/src/components/Inputs/AuthForm.js
+++ b/client/src/components/Inputs/AuthForm.js
@@ -31,6 +31,11 @@ export function AuthForm({ signUp, handleSignUp, handleLogIn }) {
 		mode: 'onChange',
 	});
 
+	// setIsModalOpen을 useCallBack으로 감싸서 자식 컴포넌트에 넘겨준다.
+	const setIsModalOpenCallback = useCallback(() => {
+		setIsModalOpen(true);
+	}, [isModalOpen]);
+
 	// 인풋별 register
 	const { ref: ref1, ...rest1 } = register('이메일', {
 		required: '이메일을 작성해주세요.',
@@ -178,15 +183,6 @@ export function AuthForm({ signUp, handleSignUp, handleLogIn }) {
 			handleLogIn(data);
 		}
 	};
-
-	// console.log('wat', watch());
-	// console.log('err', errors);
-	// console.log('current', current);
-
-	// setIsModalOpen을 useCallBack으로 감싸서 자식 컴포넌트에 넘겨준다.
-	const setIsModalOpenCallback = useCallback(() => {
-		setIsModalOpen(true);
-	}, [isModalOpen]);
 
 	return (
 		<SForm

--- a/client/src/hooks/useFetch.js
+++ b/client/src/hooks/useFetch.js
@@ -1,0 +1,23 @@
+import { useQuery } from 'react-query';
+import axios from 'axios';
+
+// export const fetchData = async (url) => {
+// 	const { data } = await axiosInstance.get(url).json();
+
+// 	return data.data;
+// };
+
+const useGet = (url, keyValue) => {
+	const { isLoading, isError, data } = useQuery(
+		keyValue,
+		() => axios.get(url),
+		{
+			cacheTime: Infinity,
+		},
+	);
+	console.log('isLoading', isLoading);
+	console.log('data', data);
+	return { isLoading, isError, data: data?.data };
+};
+
+export default useGet;

--- a/client/src/hooks/useLogin.js
+++ b/client/src/hooks/useLogin.js
@@ -1,6 +1,9 @@
+/* eslint-disable no-promise-executor-return */
 import { useState } from 'react';
 import { useMutation } from 'react-query';
 import { useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
 import { fetchLogIn } from '../apis/userApis';
 import { login } from '../redux/slice/userSlice';
 
@@ -10,17 +13,18 @@ const ERROR_MESSAGE = {
 };
 
 export default function useLogIn() {
+	const navigate = useNavigate();
 	const dispatch = useDispatch();
 	const [errMsg, setErrMsg] = useState('');
 	const { mutate, isLoading, isSuccess, isError } = useMutation(
-		// () =>
-		// 	new Promise(() => {
-		// 		return { accessToken: 'asdasd', refreshToken: 'sdfsdf' };
-		// 	}),
-		(form) => fetchLogIn(form),
+		() => ({ accessToken: 'asdasd', refreshToken: 'sdfsdf' }),
+		// (form) => fetchLogIn(form),
 		{
 			onSuccess: async (data, { email }) => {
-				dispatch(login({ accessToken: data.split(' ')[1], email }));
+				dispatch(login({ accessToken: data, email }));
+				// dispatch(login({ accessToken: data.split(' ')[1], email }));
+				toast.success('로그인 되었습니다 !');
+				navigate('/', { replace: true });
 			},
 			onError: async (data) => {
 				const { response } = data;
@@ -33,6 +37,7 @@ export default function useLogIn() {
 				} else {
 					setErrMsg(errorData.message);
 				}
+				toast.error(errMsg);
 			},
 		},
 	);

--- a/client/src/hooks/useLogin.js
+++ b/client/src/hooks/useLogin.js
@@ -17,14 +17,14 @@ export default function useLogIn() {
 	const dispatch = useDispatch();
 	const [errMsg, setErrMsg] = useState('');
 	const { mutate, isLoading, isSuccess, isError } = useMutation(
-		() => ({ accessToken: 'asdasd', refreshToken: 'sdfsdf' }),
-		// (form) => fetchLogIn(form),
+		// () => ({ accessToken: 'asdasd', refreshToken: 'sdfsdf' }),
+		(form) => fetchLogIn(form),
 		{
 			onSuccess: async (data, { email }) => {
-				dispatch(login({ accessToken: data, email }));
+				// dispatch(login({ accessToken: data, email }));
 				// dispatch(login({ accessToken: data.split(' ')[1], email }));
 				toast.success('로그인 되었습니다 !');
-				navigate('/', { replace: true });
+				// navigate('/', { replace: true });
 			},
 			onError: async (data) => {
 				const { response } = data;

--- a/client/src/hooks/useLogin.js
+++ b/client/src/hooks/useLogin.js
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useMutation } from 'react-query';
 import { useDispatch } from 'react-redux';
-import { fetchLogin } from '../apis/login';
+import { fetchLogIn } from '../apis/userApis';
 import { login } from '../redux/slice/userSlice';
 
 const ERROR_MESSAGE = {
@@ -9,7 +9,7 @@ const ERROR_MESSAGE = {
 	Forbidden: '유효하지 않은 접근입니다.',
 };
 
-export default function useLogin() {
+export default function useLogIn() {
 	const dispatch = useDispatch();
 	const [errMsg, setErrMsg] = useState('');
 	const { mutate, isLoading, isSuccess, isError } = useMutation(
@@ -17,7 +17,7 @@ export default function useLogin() {
 		// 	new Promise(() => {
 		// 		return { accessToken: 'asdasd', refreshToken: 'sdfsdf' };
 		// 	}),
-		(form) => fetchLogin(form),
+		(form) => fetchLogIn(form),
 		{
 			onSuccess: async (data, { email }) => {
 				dispatch(login({ accessToken: data.split(' ')[1], email }));

--- a/client/src/hooks/useLogin.js
+++ b/client/src/hooks/useLogin.js
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { useMutation } from 'react-query';
+import { useDispatch } from 'react-redux';
+import { fetchLogin } from '../apis/login';
+import { login } from '../redux/slice/userSlice';
+
+const ERROR_MESSAGE = {
+	Unauthorized: '아이디 또는 비밀번호를 다시 확인해주세요.',
+	Forbidden: '유효하지 않은 접근입니다.',
+};
+
+export default function useLogin() {
+	const dispatch = useDispatch();
+	const [errMsg, setErrMsg] = useState('');
+	const { mutate, isLoading, isSuccess, isError } = useMutation(
+		// () =>
+		// 	new Promise(() => {
+		// 		return { accessToken: 'asdasd', refreshToken: 'sdfsdf' };
+		// 	}),
+		(form) => fetchLogin(form),
+		{
+			onSuccess: async (data, { email }) => {
+				dispatch(login({ accessToken: data.split(' ')[1], email }));
+			},
+			onError: async (data) => {
+				const { response } = data;
+				const { status, data: errorData } = response;
+
+				if (status === 401) {
+					setErrMsg(ERROR_MESSAGE.Unauthorized);
+				} else if (status === 403) {
+					setErrMsg(ERROR_MESSAGE.Forbidden);
+				} else {
+					setErrMsg(errorData.message);
+				}
+			},
+		},
+	);
+
+	return { mutate, isLoading, isSuccess, isError, errMsg };
+}

--- a/client/src/pages/Auth/LogIn.js
+++ b/client/src/pages/Auth/LogIn.js
@@ -1,5 +1,6 @@
 import { useSelector } from 'react-redux';
 import { Link, useNavigate } from 'react-router-dom';
+import { toast } from 'react-toastify';
 import useLogIn from '../../hooks/useLogIn';
 import AuthTitle from '../../components/Etc/AuthTitle';
 import { AuthForm } from '../../components/Inputs/AuthForm';
@@ -32,7 +33,11 @@ function LogIn() {
 
 	const handleLogIn = (data) => {
 		mutate({ email: data.이메일, password: data.비밀번호 });
+		toast.success('로그인 되었습니다 !');
 		navigate(-1, { replace: true });
+	};
+	const handleToast = () => {
+		toast.success('로그인 되었습니다 !');
 	};
 
 	return (
@@ -47,6 +52,9 @@ function LogIn() {
 						회원가입
 					</text> */}
 				</LinkContainer>
+				<button type="button" onClick={handleToast}>
+					toast
+				</button>
 			</FormContainer>
 			<Background>
 				<Text>With Pillivery Ready For Life</Text>

--- a/client/src/pages/Auth/LogIn.js
+++ b/client/src/pages/Auth/LogIn.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-return-assign */
 import { useSelector } from 'react-redux';
 import { Link, useNavigate } from 'react-router-dom';
-import useLogin from '../../apis/login';
+import useLogin from '../../hooks/useLogin';
 import AuthTitle from '../../components/Etc/AuthTitle';
 import { AuthForm } from '../../components/Inputs/AuthForm';
 import {

--- a/client/src/pages/Auth/LogIn.js
+++ b/client/src/pages/Auth/LogIn.js
@@ -1,5 +1,5 @@
 import { useSelector } from 'react-redux';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { toast } from 'react-toastify';
 import useLogIn from '../../hooks/useLogIn';
 import AuthTitle from '../../components/Etc/AuthTitle';
@@ -16,8 +16,6 @@ import SocialLogIn from './SocialLogIn';
 // 로그인 페이지
 function LogIn() {
 	// 다른 페이지로 이동 후 뒤로가기 시 로그인 페이지로 이동하지 않도록 함
-	const navigate = useNavigate();
-
 	const { mutate, isLoading, isSuccess, isError } = useLogIn();
 	const { loginStatus, accessToken, email } = useSelector(
 		(store) => store.user,
@@ -31,11 +29,29 @@ function LogIn() {
 		accessToken,
 	);
 
+	const url = new URL(window.location.href);
+	console.log('🚀 ~ file: SignUp.js ~ url', url);
+	const token = url.searchParams.get('accessToken');
+	console.log('🚀 ~ file: SignUp.js ~ token', token);
+
 	const handleLogIn = (data) => {
 		mutate({ email: data.이메일, password: data.비밀번호 });
 	};
-	const handleToast = () => {
-		toast.success('로그인 되었습니다 !');
+
+	const LoginData = {
+		username: 'tkfka156@gmail.com',
+		password: 'sdfkemdff',
+	};
+	const URI =
+		'http://ec2-43-201-37-71.ap-northeast-2.compute.amazonaws.com:8080';
+	const logIn = () => {
+		fetch(`${URI}/users/login`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(LoginData),
+		})
+			.then((res) => res.json())
+			.then((res) => console.log(res));
 	};
 
 	return (
@@ -50,8 +66,8 @@ function LogIn() {
 						회원가입
 					</text> */}
 				</LinkContainer>
-				<button type="button" onClick={handleToast}>
-					toast
+				<button type="button" onClick={logIn}>
+					로그인
 				</button>
 			</FormContainer>
 			<Background>

--- a/client/src/pages/Auth/LogIn.js
+++ b/client/src/pages/Auth/LogIn.js
@@ -31,11 +31,16 @@ function LogIn() {
 		accessToken,
 	);
 
+	const handleLogIn = (data) => {
+		mutate({ email: data.이메일, password: data.비밀번호 });
+		navigate(-1, { replace: true });
+	};
+
 	return (
 		<AuthContainer>
 			<FormContainer>
 				<AuthTitle title="로그인" />
-				<AuthForm mutate={mutate} />
+				<AuthForm handleLogIn={handleLogIn} />
 				<SocialLogin />
 				<LinkContainer>
 					아직 회원이 아니신가요? <Link to="/signup">회원가입</Link>

--- a/client/src/pages/Auth/LogIn.js
+++ b/client/src/pages/Auth/LogIn.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-return-assign */
+import { useSelector } from 'react-redux';
 import { Link, useNavigate } from 'react-router-dom';
 import useLogin from '../../apis/login';
 import AuthTitle from '../../components/Etc/AuthTitle';
@@ -18,6 +19,17 @@ function LogIn() {
 	const navigate = useNavigate();
 
 	const { mutate, isLoading, isSuccess, isError } = useLogin();
+	const { loginStatus, accessToken, email } = useSelector(
+		(store) => store.user,
+	);
+	console.log(
+		'email',
+		email,
+		'loginStatus',
+		loginStatus,
+		'accessToken',
+		accessToken,
+	);
 
 	return (
 		<AuthContainer>

--- a/client/src/pages/Auth/LogIn.js
+++ b/client/src/pages/Auth/LogIn.js
@@ -33,8 +33,6 @@ function LogIn() {
 
 	const handleLogIn = (data) => {
 		mutate({ email: data.이메일, password: data.비밀번호 });
-		toast.success('로그인 되었습니다 !');
-		navigate(-1, { replace: true });
 	};
 	const handleToast = () => {
 		toast.success('로그인 되었습니다 !');

--- a/client/src/pages/Auth/LogIn.js
+++ b/client/src/pages/Auth/LogIn.js
@@ -1,7 +1,6 @@
-/* eslint-disable no-return-assign */
 import { useSelector } from 'react-redux';
 import { Link, useNavigate } from 'react-router-dom';
-import useLogin from '../../hooks/useLogin';
+import useLogIn from '../../hooks/useLogIn';
 import AuthTitle from '../../components/Etc/AuthTitle';
 import { AuthForm } from '../../components/Inputs/AuthForm';
 import {
@@ -11,14 +10,14 @@ import {
 	LinkContainer,
 	Text,
 } from './SignUp';
-import SocialLogin from './SocialLogin';
+import SocialLogIn from './SocialLogIn';
 
 // 로그인 페이지
 function LogIn() {
 	// 다른 페이지로 이동 후 뒤로가기 시 로그인 페이지로 이동하지 않도록 함
 	const navigate = useNavigate();
 
-	const { mutate, isLoading, isSuccess, isError } = useLogin();
+	const { mutate, isLoading, isSuccess, isError } = useLogIn();
 	const { loginStatus, accessToken, email } = useSelector(
 		(store) => store.user,
 	);
@@ -41,7 +40,7 @@ function LogIn() {
 			<FormContainer>
 				<AuthTitle title="로그인" />
 				<AuthForm handleLogIn={handleLogIn} />
-				<SocialLogin />
+				<SocialLogIn />
 				<LinkContainer>
 					아직 회원이 아니신가요? <Link to="/signup">회원가입</Link>
 					{/* <text onClick={() => navigate('/signup', { replace: true })}>

--- a/client/src/pages/Auth/SignUp.js
+++ b/client/src/pages/Auth/SignUp.js
@@ -6,7 +6,7 @@ import { AuthForm } from '../../components/Inputs/AuthForm';
 import axiosInstance from '../../utils/axiosInstance';
 
 // const URI = 'http://ec2-3-35-17-245.ap-northeast-2.compute.amazonaws.com:8080';
-const URI = 'https://true.loca.lt/';
+const URI = 'https://wicked-husky-45.loca.lt';
 const data = {
 	displayName: 'sdfsdf',
 	address: 'sdgelblf',
@@ -43,15 +43,15 @@ function SignUp() {
 			.then((res) => console.log(res));
 	};
 
-	// const handleLogIn = () => {
-	// 	fetch(`${URI}/users/login`, {
-	// 		method: 'POST',
-	// 		headers: { 'Content-Type': 'application/json' },
-	// 		body: JSON.stringify(LoginData),
-	// 	})
-	// 		.then((res) => res.json())
-	// 		.then((res) => console.log(res));
-	// };
+	const handleLogIn = () => {
+		fetch(`${URI}/users/login`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(LoginData),
+		})
+			.then((res) => res.json())
+			.then((res) => console.log(res));
+	};
 
 	// 닉네임: 'asd';
 	// 비밀번호: 'asdfg';
@@ -62,12 +62,12 @@ function SignUp() {
 	// 전화번호: '010-123-123';
 	// 주소: '(12417)경기 가평군 가평읍 광장로22번길 27-9';
 
-	const handleLogIn = (userData) => {
-		axiosInstance
-			.post(`/users/login`, userData)
-			.then((res) => console.log(res))
-			.catch((err) => console.log(err));
-	};
+	// const handleLogIn = (userData) => {
+	// 	axiosInstance
+	// 		.post(`/users/login`, userData)
+	// 		.then((res) => console.log(res))
+	// 		.catch((err) => console.log(err));
+	// };
 
 	const handleMoreInfo = () => {
 		fetch(`${URI}/users/more-info`, {

--- a/client/src/pages/Auth/SignUp.js
+++ b/client/src/pages/Auth/SignUp.js
@@ -13,7 +13,7 @@ import { AuthForm } from '../../components/Inputs/AuthForm';
 import { fetchSignUp } from '../../apis/userApis';
 
 // const URI = 'http://ec2-3-35-17-245.ap-northeast-2.compute.amazonaws.com:8080';
-const URI = 'https://wicked-husky-45.loca.lt';
+const URI = 'http://ec2-43-201-37-71.ap-northeast-2.compute.amazonaws.com:8080';
 const data = {
 	displayName: 'sdfsdf',
 	address: 'sdgelblf',
@@ -21,12 +21,7 @@ const data = {
 	realName: 'gmeif',
 	phone: '030303013030',
 	email: 'tkfka156@gmail.com',
-	password: 'sdfkemdff',
-};
-
-const LoginData = {
-	username: 'tkfka156@gmail.com',
-	password: 'sdfkemdff',
+	password: 'asdfg',
 };
 
 const moreInfoData = {
@@ -40,21 +35,11 @@ const moreInfoData = {
 
 // 회원가입 페이지
 function SignUp() {
-	const handleGet = () => {
+	const signUp = () => {
 		fetch(`${URI}/users`, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify(data),
-		})
-			.then((res) => res.json())
-			.then((res) => console.log(res));
-	};
-
-	const handleLogIn = () => {
-		fetch(`${URI}/users/login`, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(LoginData),
 		})
 			.then((res) => res.json())
 			.then((res) => console.log(res));
@@ -108,27 +93,24 @@ function SignUp() {
 	};
 
 	// url 파라미터 콘솔에 찍기
-	const url = new URL(window.location.href);
-	console.log('🚀 ~ file: SignUp.js ~ url', url);
-	const email = url.searchParams.get('email');
-	console.log('🚀 ~ file: SignUp.js ~ email', email);
+	// const url = new URL(window.location.href);
+	// console.log('🚀 ~ file: SignUp.js ~ url', url);
+	// const email = url.searchParams.get('email');
+	// console.log('🚀 ~ file: SignUp.js ~ email', email);
 	const [searchParams] = useSearchParams();
-	console.log('🚀 ~ file: SignUp.js ~ searchParams', searchParams);
-	const email2 = searchParams.get('email2') || '';
-	console.log('🚀 ~ file: SignUp.js ~ email', email);
-	const location = useLocation();
-	console.log('🚀 ~ file: SignUp.js ~ location', location);
+	// console.log('🚀 ~ file: SignUp.js ~ searchParams: ', searchParams);
+	const accessToken = searchParams.get('access_token') || '';
+	console.log('🚀 ~ file: SignUp.js ~ accessToken: ', accessToken);
+	// const location = useLocation();
+	// console.log('🚀 ~ file: SignUp.js ~ location', location);
 
 	return (
 		<AuthContainer>
 			<FormContainer>
 				<AuthTitle title="회원가입" />
 				<AuthForm signUp handleSignUp={handleSignUp} />
-				<button type="button" onClick={handleGet}>
+				<button type="button" onClick={signUp}>
 					회원가입
-				</button>
-				<button type="button" onClick={handleLogIn}>
-					로그인
 				</button>
 				<button type="button" onClick={handleLogOut}>
 					로그아웃

--- a/client/src/pages/Auth/SignUp.js
+++ b/client/src/pages/Auth/SignUp.js
@@ -62,12 +62,12 @@ function SignUp() {
 	// 전화번호: '010-123-123';
 	// 주소: '(12417)경기 가평군 가평읍 광장로22번길 27-9';
 
-	// const handleLogIn = (userData) => {
-	// 	axiosInstance
-	// 		.post(`/users/login`, userData)
-	// 		.then((res) => console.log(res))
-	// 		.catch((err) => console.log(err));
-	// };
+	const handleSignUp = (userData) => {
+		axiosInstance
+			.post(`/users/login`, userData)
+			.then((res) => console.log(res))
+			.catch((err) => console.log(err));
+	};
 
 	const handleMoreInfo = () => {
 		fetch(`${URI}/users/more-info`, {
@@ -101,7 +101,7 @@ function SignUp() {
 		<AuthContainer>
 			<FormContainer>
 				<AuthTitle title="회원가입" />
-				<AuthForm signUp handleLogIn={handleLogIn} />
+				<AuthForm signUp handleSignUp={handleSignUp} />
 				<button type="button" onClick={handleGet}>
 					회원가입
 				</button>

--- a/client/src/pages/Auth/SignUp.js
+++ b/client/src/pages/Auth/SignUp.js
@@ -1,9 +1,10 @@
+/* eslint-disable no-shadow */
 import styled from 'styled-components';
-// import axios from 'axios';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useSearchParams } from 'react-router-dom';
+import { toast } from 'react-toastify';
 import AuthTitle from '../../components/Etc/AuthTitle';
 import { AuthForm } from '../../components/Inputs/AuthForm';
-import axiosInstance from '../../utils/axiosInstance';
+import { fetchSignUp } from '../../apis/userApis';
 
 // const URI = 'http://ec2-3-35-17-245.ap-northeast-2.compute.amazonaws.com:8080';
 const URI = 'https://wicked-husky-45.loca.lt';
@@ -62,11 +63,9 @@ function SignUp() {
 	// 전화번호: '010-123-123';
 	// 주소: '(12417)경기 가평군 가평읍 광장로22번길 27-9';
 
-	const handleSignUp = (userData) => {
-		axiosInstance
-			.post(`/users/login`, userData)
-			.then((res) => console.log(res))
-			.catch((err) => console.log(err));
+	const handleSignUp = (data) => {
+		fetchSignUp(data);
+		toast.success('회원가입을 축하합니다 !');
 	};
 
 	const handleMoreInfo = () => {
@@ -93,9 +92,15 @@ function SignUp() {
 
 	// url 파라미터 콘솔에 찍기
 	const url = new URL(window.location.href);
-	console.log('🚀 ~ file: SignUp.js ~ line 82 ~ SignUp ~ url', url);
+	console.log('🚀 ~ file: SignUp.js ~ url', url);
 	const email = url.searchParams.get('email');
-	console.log('🚀 ~ file: SignUp.js ~ line 83 ~ SignUp ~ email', email);
+	console.log('🚀 ~ file: SignUp.js ~ email', email);
+	const [searchParams] = useSearchParams();
+	console.log('🚀 ~ file: SignUp.js ~ searchParams', searchParams);
+	const email2 = searchParams.get('email2') || '';
+	console.log('🚀 ~ file: SignUp.js ~ email', email);
+	const location = useLocation();
+	console.log('🚀 ~ file: SignUp.js ~ location', location);
 
 	return (
 		<AuthContainer>

--- a/client/src/pages/Auth/SignUp.js
+++ b/client/src/pages/Auth/SignUp.js
@@ -1,7 +1,13 @@
 /* eslint-disable no-shadow */
 import styled from 'styled-components';
-import { Link, useLocation, useSearchParams } from 'react-router-dom';
+import {
+	Link,
+	useLocation,
+	useNavigate,
+	useSearchParams,
+} from 'react-router-dom';
 import { toast } from 'react-toastify';
+import { useMutation } from 'react-query';
 import AuthTitle from '../../components/Etc/AuthTitle';
 import { AuthForm } from '../../components/Inputs/AuthForm';
 import { fetchSignUp } from '../../apis/userApis';
@@ -62,10 +68,21 @@ function SignUp() {
 	// 이메일: 'coding@naver.com';
 	// 전화번호: '010-123-123';
 	// 주소: '(12417)경기 가평군 가평읍 광장로22번길 27-9';
+	const navigate = useNavigate();
+
+	const { mutate } = useMutation((form) => fetchSignUp(form), {
+		onSuccess: () => {
+			toast.success('회원가입을 축하합니다 !');
+			navigate('/login');
+		},
+		onError: (error) => {
+			console.error(error);
+			toast.error(error.response.data.message);
+		},
+	});
 
 	const handleSignUp = (data) => {
-		fetchSignUp(data);
-		toast.success('회원가입을 축하합니다 !');
+		mutate(data);
 	};
 
 	const handleMoreInfo = () => {

--- a/client/src/pages/Auth/SocialLogin.js
+++ b/client/src/pages/Auth/SocialLogin.js
@@ -64,7 +64,7 @@ const SocialButton = styled.button`
 `;
 
 export default function SocialLogin() {
-	const URI = 'https://true.loca.lt/oauth2/authorization';
+	const URI = 'https://wicked-husky-45.loca.lt/oauth2/authorization';
 	const loginRequestHandler = (type) => {
 		window.location.assign((window.location.href = `${URI}/${type}`));
 	};

--- a/client/src/pages/Auth/SocialLogin.js
+++ b/client/src/pages/Auth/SocialLogin.js
@@ -63,7 +63,7 @@ const SocialButton = styled.button`
 	}
 `;
 
-export default function SocialLogin() {
+export default function SocialLogIn() {
 	const URI = 'https://wicked-husky-45.loca.lt/oauth2/authorization';
 	const loginRequestHandler = (type) => {
 		window.location.assign((window.location.href = `${URI}/${type}`));

--- a/client/src/pages/Auth/SocialLogin.js
+++ b/client/src/pages/Auth/SocialLogin.js
@@ -64,7 +64,8 @@ const SocialButton = styled.button`
 `;
 
 export default function SocialLogIn() {
-	const URI = 'https://wicked-husky-45.loca.lt/oauth2/authorization';
+	const URI =
+		'http://ec2-43-201-37-71.ap-northeast-2.compute.amazonaws.com:8080/oauth2/authorization';
 	const loginRequestHandler = (type) => {
 		window.location.assign((window.location.href = `${URI}/${type}`));
 	};

--- a/client/src/pages/MyPages/UserInfo.js
+++ b/client/src/pages/MyPages/UserInfo.js
@@ -2,6 +2,7 @@
 /* eslint-disable no-param-reassign */
 // 회원정보
 import { useCallback, useState } from 'react';
+
 import styled from 'styled-components';
 import Postcode from '@actbase/react-daum-postcode';
 import { useForm } from 'react-hook-form';
@@ -14,6 +15,12 @@ import AddressModal from '../../components/Modals/AddressModal';
 import GoodbyeModal from '../../components/Modals/GoodbyeModal';
 
 export function UserInfo() {
+	// const {
+	// 	isLoading,
+	// 	isError,
+	// 	data: test,
+	// } = useFetch('https://koreanjson.com/posts/1', 'dada');
+	// console.log(isLoading, test, isError);
 	const user = {
 		displayName: 'loopy',
 		email: 'loopy@gmail.com',

--- a/client/src/redux/slice/userSlice.js
+++ b/client/src/redux/slice/userSlice.js
@@ -6,14 +6,15 @@ const initialState = {
 	keepLoggedIn: false,
 	accessToken: '',
 	refreshToken: '',
+	email: '',
 };
 
 const userSlice = createSlice({
-	name: 'auth',
+	name: 'user',
 	initialState,
 	reducers: {
 		login: (state, { payload }) => {
-			const { accessToken, refreshToken, keepLoggedIn } = payload;
+			const { accessToken, refreshToken, email, keepLoggedIn } = payload;
 
 			if (keepLoggedIn) {
 				state.keepLoggedIn = true;
@@ -21,6 +22,7 @@ const userSlice = createSlice({
 			state.accessToken = accessToken;
 			state.refreshToken = refreshToken;
 			state.loginStatus = true;
+			state.email = email;
 		},
 		logout: () => {
 			return initialState;

--- a/client/src/redux/store/store.js
+++ b/client/src/redux/store/store.js
@@ -3,7 +3,7 @@ import userSlice from '../slice/userSlice';
 
 const store = configureStore({
 	reducer: {
-		auth: userSlice.reducer,
+		user: userSlice.reducer,
 	},
 });
 

--- a/client/src/utils/axiosInstance.js
+++ b/client/src/utils/axiosInstance.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const axiosInstance = axios.create({
-	baseURL: 'https://wicked-husky-45.loca.lt', // 서버 url
+	baseURL: 'http://ec2-43-201-37-71.ap-northeast-2.compute.amazonaws.com:8080', // 서버 url
 	timeout: 5000,
 });
 

--- a/client/src/utils/axiosInstance.js
+++ b/client/src/utils/axiosInstance.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const axiosInstance = axios.create({
-	baseURL: 'https://dangerous-newt-46.loca.lt', // 서버 url
+	baseURL: 'https://wicked-husky-45.loca.lt', // 서버 url
 	timeout: 5000,
 });
 


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #86 #108 #112 #138

<br>

## 무엇이 추가 되었나요?
1. 회원가입/로그인 페이지 API 통신 후 리덕스에 정보 저장
2. React-toastify로 회원가입/로그인 안내창 구현
3. useFetch hook 구현

<br>

## 기타 정보

<br>
