### PR TITLE
[Client]로그아웃, 회원탈퇴 시 로컬스토리지 초기화 구현

### DIFF
--- a/client/src/components/Etc/MyPageHeader.js
+++ b/client/src/components/Etc/MyPageHeader.js
@@ -2,7 +2,8 @@ import axios from 'axios';
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import { toast } from 'react-toastify';
 import { TempLogo } from '../../assets/Icons';
 import { useGet } from '../../hooks/useFetch';
 import { GrayLetterButton } from '../Buttons/LetterButton';
@@ -11,7 +12,8 @@ import { logout } from '../../redux/slice/userSlice';
 function MyPageHeader() {
 	const dispatch = useDispatch();
 	const navigate = useNavigate();
-	const nickName = localStorage.getItem('displayName');
+	const { nickName } = useSelector((store) => store.nickName);
+	console.log(nickName);
 	const handleLogout = useCallback(async () => {
 		const response = await axios
 			.get(
@@ -23,6 +25,7 @@ function MyPageHeader() {
 		if (response) {
 			dispatch(logout());
 			navigate('/', { replace: true });
+			toast.success('로그아웃 되었습니다!');
 		}
 	}, []);
 	return (

--- a/client/src/pages/MyPages/UserInfo.js
+++ b/client/src/pages/MyPages/UserInfo.js
@@ -5,7 +5,8 @@ import { useCallback, useState, useEffect } from 'react';
 import styled from 'styled-components';
 import Postcode from '@actbase/react-daum-postcode';
 import { useForm } from 'react-hook-form';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import {
 	LetterButton,
 	LetterButtonColor,
@@ -13,10 +14,12 @@ import {
 import DeleteAccountModal from '../../components/Modals/DeleteAccountModal';
 import AddressModal from '../../components/Modals/AddressModal';
 import GoodbyeModal from '../../components/Modals/GoodbyeModal';
-import { useGet, useDelete, usePatch, usePost } from '../../hooks/useFetch';
+import { useGet, useDelete, usePatch } from '../../hooks/useFetch';
+import { change } from '../../redux/slice/nickNameSlice';
+import { logout } from '../../redux/slice/userSlice';
 
 export function UserInfo() {
-	const { mutate: accountDelete } = useDelete(
+	const { mutate: accountDelete, isError: deleteError } = useDelete(
 		'http://ec2-43-201-37-71.ap-northeast-2.compute.amazonaws.com:8080/users',
 	);
 	const { pathname } = useLocation();
@@ -41,7 +44,7 @@ export function UserInfo() {
 	} = useForm({
 		mode: 'onBlur',
 	});
-
+	const dispatch = useDispatch();
 	const [isModal, setModal] = useState(false);
 	const [modalIsOpen, setIsOpen] = useState(false);
 	const [openGoodbye, setOpenGoodbye] = useState(false);
@@ -51,11 +54,11 @@ export function UserInfo() {
 		if (userData) {
 			setValue('이메일', userData.data.email);
 			setValue('닉네임', userData.data.displayName);
-			setValue('비밀번호', userData.data.password);
 			setValue('이름', userData.data.realName);
 			setValue('전화번호', userData.data.phone);
 			setValue('주소', userData.data.address);
 			setValue('상세주소', userData.data.detailAddress);
+			dispatch(change(userData.data.displayName));
 		}
 	}, [userData]);
 
@@ -65,8 +68,11 @@ export function UserInfo() {
 	});
 	const handleDeleteButton = useCallback(() => {
 		accountDelete();
-		setIsOpen(false);
-		setOpenGoodbye(true);
+		if (!deleteError) {
+			dispatch(logout());
+			setIsOpen(false);
+			setOpenGoodbye(true);
+		}
 	});
 	const nicknameReg = register('닉네임', {
 		required: '닉네임을 입력해주세요.', // 빈 칸일때
@@ -144,7 +150,6 @@ export function UserInfo() {
 		console.log(value);
 		userPatch(value);
 	};
-
 	if (isLoading) return <div>정보를 불러오는 중 입니다...!</div>;
 	if (isError) return <div>{error.message}</div>;
 	return (
@@ -156,22 +161,22 @@ export function UserInfo() {
 						<Information
 							label="닉네임"
 							register={nicknameReg}
-							errors={errors?.닉네임?.message}
+							// errors={errors?.닉네임?.message}
 						/>
 						<Information
 							label="이메일"
 							register={mailReg}
-							errors={errors?.이메일?.message}
+							// errors={errors?.이메일?.message}
 						/>
 						<Information
 							label="비밀번호"
 							register={pwReg}
-							errors={errors?.비밀번호?.message}
+							// errors={errors?.비밀번호?.message}
 						/>
 						<Information
 							label="비밀번호재확인"
 							register={rePwReg}
-							errors={errors?.비밀번호재확인?.message}
+							// errors={errors?.비밀번호재확인?.message}
 						/>
 					</InputBox>
 				</InfoBox>
@@ -181,23 +186,23 @@ export function UserInfo() {
 						<Information
 							label="이름"
 							register={nameReg}
-							errors={errors?.이름?.message}
+							// errors={errors?.이름?.message}
 						/>
 						<Information
 							label="전화번호"
 							register={telReg}
-							errors={errors?.전화번호?.message}
+							// errors={errors?.전화번호?.message}
 						/>
 						<Information
 							label="주소"
 							handleOpenAddress={handleOpenAddress}
 							register={adressReg}
-							errors={errors?.주소?.message}
+							// errors={errors?.주소?.message}
 						/>
 						<Information
 							label="상세주소"
 							register={detailAddressReg}
-							errors={errors?.상세주소?.message}
+							// errors={errors?.상세주소?.message}
 						/>
 					</InputBox>
 				</InfoBox>

--- a/client/src/redux/slice/nickNameSlice.js
+++ b/client/src/redux/slice/nickNameSlice.js
@@ -1,0 +1,18 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+	nickName: '-',
+};
+
+const nickNameSlice = createSlice({
+	name: 'nickName',
+	initialState,
+	reducers: {
+		change: (state, action) => {
+			Object.assign(state, { nickName: action.payload });
+		},
+	},
+});
+
+export const { change } = nickNameSlice.actions;
+export default nickNameSlice;

--- a/client/src/redux/slice/userSlice.js
+++ b/client/src/redux/slice/userSlice.js
@@ -36,6 +36,7 @@ const userSlice = createSlice({
 			state.isSocial = isSocial;
 		},
 		logout: () => {
+			localStorage.clear();
 			return initialState;
 		},
 	},

--- a/client/src/redux/store/store.js
+++ b/client/src/redux/store/store.js
@@ -1,11 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 import userSlice from '../slice/userSlice';
 import filterSlice from '../slice/filterSlice';
+import nickNameSlice from '../slice/nickNameSlice';
 
 const store = configureStore({
 	reducer: {
 		user: userSlice.reducer,
 		filter: filterSlice.reducer,
+		nickName: nickNameSlice.reducer,
 	},
 });
 


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #173 

<br>

## 무엇이 추가 되었나요?
개인정보 수정 시 마이페이지의 회원정보가 바로 수정되도록 구현했습니다. 이를 위해 리덕스툴킷을 사용했습니다.
로그아웃 회원탈퇴 시에 로컬스토리지에 있는 토큰이 삭제되도록 구현했습니다. 
<br>

## 기타 정보

<br>
