### PR TITLE
[Client] 탭 버튼 props로 onClick 전달하지 않은 경우에 발생하는 에러 해결

### DIFF
--- a/client/src/components/Lists/MyPageLists/OrderList.js
+++ b/client/src/components/Lists/MyPageLists/OrderList.js
@@ -15,7 +15,7 @@ function OrderList({ list }) {
 
 	return (
 		<Box>
-			<Image src={list.itemOrders[0].item.thumbnail} alt="상품 이미지" />
+			<Image src={list.item.thumbnail} alt="상품 이미지" />
 			<MainContainer>
 				<InfoContainer>
 					<ShoppingInfo>
@@ -23,10 +23,17 @@ function OrderList({ list }) {
 						<DotDate date={list.createdAt} />
 					</ShoppingInfo>
 					<Name>
-						{list.itemOrders[0].item.brand}, {list.itemOrders[0].item.title}{' '}
-						{list.itemOrders.length > 1 && `외 ${list.itemOrders.length - 1}개`}
+						{`${list.item.brand}, ${list.item.title} 
+						${list.item.length > 1 && `외 ${list.item.totalItems - 1}개`}`}
 					</Name>
-					<Price nowPrice={list.itemOrders[0].item.price} isTotal />
+					<Price
+						nowPrice={list.item.discountPrice || list.item.price}
+						discountRate={
+							list.item.discountRate === 0 ? '' : list.item.discountRate
+						}
+						beforePrice={list.item.discountPrice ? list.item.price : null}
+						isTotal
+					/>
 				</InfoContainer>
 				<BtnContainer>
 					<IconBtnContainer onClick={handleDetailBtnClick}>

--- a/client/src/components/Tabs/DefaultTabButton.js
+++ b/client/src/components/Tabs/DefaultTabButton.js
@@ -67,7 +67,9 @@ function DefaultTabButton({
 				break;
 		}
 
-		onClick(e);
+		if (onClick) {
+			onClick(e);
+		}
 
 		/*
 		! 위에 onClick 이거 뭐지? 싶으신 분들 ~~!!


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #130

<br>

## 무엇이 추가 되었나요?

탭 버튼 클릭 시 실행시킬 함수를 props로 내릴 수 있도록 처리하는 과정에서,
props로 `onClick`을 받지 않아도 `onClick`이 실행되는 에러를 발견하여 수정하였습니다.

<br>

## 기타 정보

> 수정 전
```js
const handleBtnClick = useCallback((e) => {
  ...
  onClick(e)
  ...
}
```

> 수정 후
```js
const handleBtnClick = useCallback((e) => {
  ...
  if (onClick) {
    onClick(e)
  }
  ...
}
```

<br>
