### PR TITLE
[Client] 상세페이지 별점, 정보, 토크 관련 구현 및 수정

### DIFF
--- a/client/src/components/Etc/ItemDetailInfo.js
+++ b/client/src/components/Etc/ItemDetailInfo.js
@@ -1,0 +1,73 @@
+import styled from 'styled-components';
+
+export function DeliveryInfo() {
+	const info = `배송 방법 : 택배 배송
+	배송 지역 : 전국
+	배송 비용 : 무료
+	배송 예정일 : 평일 기준 출고 후 1~2일 소요 (관할 지역 택배사 사정에 따라 추가 소요될 수 있음)
+
+	천재지변, 물량 급증, 수급 변동 등 예외적인 사유 발생 시, 배송이 지연될 수 있는 점 양해 부탁드립니다.
+	군부대 일부와 해외의 경우 배송이 어려울 수 있습니다
+	
+	평일 낮 12시 이전 결제 시 : 당일 출고 (주말 및 공휴일 제외)
+	평일 낮 12시 이후 결제 시 : 다음날 출고 (주말 및 공휴일 제외)`;
+	return <InfoContent>{info}</InfoContent>;
+}
+
+export function ReturnInfo() {
+	const info = `교환/반품 안내
+	- 단순 변심에 의한 교환 / 반품은 제품 수량 후 7일까지 가능하며 왕복 배송비는 고객부담입니다.
+	- 상세주소 미입력, 주소지 오기재 등으로 인해 상품이 반송될 경우 왕복 배송비는 고객부담입니다.
+	- 고객 사유로 인한 교환/반품/반송 시 왕복 배송비 5,000원이 발생하며 제주 및 도서산간 지역의 경우 실제 왕복 배송비가 부과됩니다.
+	- 상품 불량 및 오배송 등으로 인한 귀책 사유가 있을 경우, 교환/반품 배송비는 필리버리가 부담합니다.
+	
+	교환/반품 제한사항
+	- 고객의 사용, 시간경과, 제품 소비에 의해 제품의 가치가 현저히 감소한 경우
+	- 구성품의 분실, 누락, 파손 혹은 포장이 훼손되어 제품의 가치가 현저히 감소한 경우`;
+
+	return <InfoContent>{info}</InfoContent>;
+}
+
+export function ProductInfo({
+	expiration,
+	capacity,
+	servingSize,
+	nutritionFacts,
+}) {
+	const info = `상품 유형
+	건강기능식품
+
+	유통기한
+	${expiration} 까지
+
+	영양 정보
+	- 용량 : ${capacity}정 (${capacity / servingSize}일)
+	- 영양성분 : ${nutritionFacts.map(
+		(fact) => ` ${fact.ingredient} (${fact.volume})`,
+	)}
+	- 1일 섭취량: 1회 ${servingSize}정
+
+	섭취 방법
+	1일 1회, 1회 ${servingSize}캡슐을 충분한 물과 함께 섭취하십시오.
+
+	섭취 시 주의사항
+	- 질환이 있거나 의약품 복용 시 전문가와 상담하십시오.
+	- 알레르기 체질 등은 개인에 따라 과민반응을 나타낼 수 있습니다.
+	- 이상사례 발생 시 섭취를 중단하고 전문가와 상담하십시오.
+	- 어린이가 함부로 섭취하지 않도록 일일섭취량 방법을 지도하십시오.
+	- 강력방습제(실리카겔)는 섭취하지 마십시오.
+
+	보관 방법
+	- 수분 및 열에 의해 품질에 영향을 받을 수 있으므로 직사광선을 피해 서늘한 곳에 보관하시고, 어린이 손에 닿지 않는 곳에 보관하십시오.
+- 충격에 제품이 깨질 수 있으니 주의하십시오.
+	`;
+
+	return <InfoContent>{info}</InfoContent>;
+}
+
+const InfoContent = styled.pre`
+	white-space: pre-line;
+	font-size: 15px;
+	line-height: 1.5;
+	color: var(--gray-400);
+`;

--- a/client/src/components/ItemSummary/Summary.js
+++ b/client/src/components/ItemSummary/Summary.js
@@ -25,6 +25,7 @@ function Summary({
 	wishlist,
 	starAvg,
 	reviewCount,
+	handleMoveToReview,
 }) {
 	const { pathname } = useLocation();
 	const { id } = useParams();
@@ -166,6 +167,7 @@ function Summary({
 								star={Math.floor(starAvg)}
 								average={starAvg}
 								count={reviewCount}
+								onClick={handleMoveToReview}
 							/>
 							<SummaryPrice
 								nowPrice={nowPrice}

--- a/client/src/components/Lists/MainListCard.js
+++ b/client/src/components/Lists/MainListCard.js
@@ -19,7 +19,7 @@ function MainListCard({ item }) {
 					<ContentContainer middle>
 						<ItemImg src={item.thumbnail} alt="상품 이미지" />
 					</ContentContainer>
-					<ContentContainer bottom>
+					<ContentContainer bottom onClick={handleItemClick}>
 						<div className="title brandName">{item.brand}</div>
 						<NamePriceBox>
 							<div className="title itemName">{item.title}</div>
@@ -39,6 +39,7 @@ function MainListCard({ item }) {
 						<ShortTextStar
 							starAvg={item.starAvg}
 							reviewCount={item.reviewSize}
+							main="main"
 						/>
 					</ContentContainer>
 					<ContentContainer middle>
@@ -100,18 +101,16 @@ const DefaultContainer = styled.div`
 const ContentBox = styled.div`
 	display: flex;
 	flex-direction: column;
-	padding: 24px 24px 33px 24px;
+	padding: 25px 25px 33px 25px;
 `;
 const ContentContainer = styled.div`
 	display: flex;
 	flex-direction: row-reverse;
-	margin-top: 10px;
 	${(props) =>
 		props.middle
 			? css`
-					padding-top: 58px;
 					justify-content: center;
-					padding-bottom: 72px;
+					padding-bottom: 66px;
 			  `
 			: props.bottom
 			? css`
@@ -133,7 +132,6 @@ const ContentContainer = styled.div`
 	.itemName {
 		font-weight: var(--extraBold);
 		font-size: 20px;
-		/* padding-bottom: 27.5px; */
 		word-break: keep-all;
 	}
 	.itemPrice {
@@ -150,15 +148,18 @@ const NamePriceBox = styled.div`
 `;
 
 const ItemImg = styled.img`
-	width: 156px;
-	height: 156px;
+	width: 100%;
+	height: 100%;
 `;
 
 const ItemDescription = styled.p`
 	color: white;
-	font-size: 20px;
-	line-height: 25px;
+	font-size: 18px;
+	line-height: 26px;
 	letter-spacing: -0.04em;
 	word-break: keep-all;
+	margin-top: 70px;
+	text-align: left;
+	width: 100%;
 `;
 export default MainListCard;

--- a/client/src/components/Modals/TalkModal.js
+++ b/client/src/components/Modals/TalkModal.js
@@ -13,12 +13,12 @@ function TalkModal({ setIsOpen, modalIsOpen, talk }) {
 	const [talkContent, setTalkContent] = useState(talk.content);
 
 	// 토크 수정 hook
-	const { mutate: talkUpdateMu, response: talkUpdateRes } = usePatch(
+	const { mutate: talkUpdateMu } = usePatch(
 		`http://ec2-43-201-37-71.ap-northeast-2.compute.amazonaws.com:8080/talks/${talk.talkId}`,
 	);
 
 	// 리토크 수정 hook
-	const { mutate: reTalkUpdateMu, response: reTalkUpdateRes } = usePatch(
+	const { mutate: reTalkUpdateMu } = usePatch(
 		`http://ec2-43-201-37-71.ap-northeast-2.compute.amazonaws.com:8080/talks/comments/${talk.talkCommentId}`,
 	);
 
@@ -26,7 +26,6 @@ function TalkModal({ setIsOpen, modalIsOpen, talk }) {
 	const handleNewContent = useCallback(
 		(e) => {
 			setTalkContent(e.target.value);
-			console.log('내용:', e.target.value);
 		},
 		[talkContent],
 	);

--- a/client/src/components/Stars/TextStar.js
+++ b/client/src/components/Stars/TextStar.js
@@ -2,11 +2,11 @@ import styled from 'styled-components';
 import { FaStar } from 'react-icons/fa';
 
 // 별 다섯개
-export function LongTextStar({ noText, star, average, count }) {
+export function LongTextStar({ noText, star, average, count, onClick }) {
 	const starData = star || 0;
 
 	return (
-		<StarContainer>
+		<StarContainer onClick={onClick} className={onClick && 'pointer'}>
 			<Icon>
 				{new Array(starData).fill(0).map((el, i) => (
 					<FaStar key={`${i.toString()}`} id={el} className="yellow-star" />
@@ -26,12 +26,12 @@ export function LongTextStar({ noText, star, average, count }) {
 }
 
 // 별 하나
-export function ShortTextStar({ starAvg, reviewCount }) {
+export function ShortTextStar({ starAvg, reviewCount, main }) {
 	const starData = starAvg.toFixed(1) || 0;
 	const reviewCountData = reviewCount || 0;
 
 	return (
-		<StarContainer>
+		<StarContainer className={main && 'main'}>
 			<Icon>
 				<FaStar className="yellow-star" />
 			</Icon>
@@ -53,6 +53,16 @@ const Score = styled.div`
 const StarContainer = styled.div`
 	display: flex;
 	align-items: center;
+
+	&.main {
+		* {
+			font-size: 15px;
+		}
+	}
+
+	&.pointer {
+		cursor: pointer;
+	}
 `;
 
 const Icon = styled.div`

--- a/client/src/pages/Detail.js
+++ b/client/src/pages/Detail.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { useLocation, useParams } from 'react-router-dom';
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useRef } from 'react';
 import { toast } from 'react-toastify';
 import Summary from '../components/ItemSummary/Summary';
 import DetailReviewList from '../components/Lists/DetailReviewList';
@@ -8,10 +8,15 @@ import DetailTalkList from '../components/Lists/DetailTalkList';
 import TalkForm from '../components/Forms/TalkForm';
 import { useGet, usePost } from '../hooks/useFetch';
 import { LoadingSpinner } from '../components/Etc/LoadingSpinner';
+import {
+	DeliveryInfo,
+	ReturnInfo,
+	ProductInfo,
+} from '../components/Etc/ItemDetailInfo';
 
 function Detail() {
 	// state 초기값 토크 조회값일 수도!
-
+	const ref = useRef();
 	const { pathname } = useLocation();
 	const { id } = useParams();
 	const token = localStorage.getItem('accessToken');
@@ -49,58 +54,6 @@ function Detail() {
 		[content],
 	);
 	const lists = !isLoading && data.data.data;
-
-	const deliveryInfo = `배송 방법 : 택배 배송
-	배송 지역 : 전국
-	배송 비용 : 무료
-	배송 예정일 : 평일 기준 출고 후 1~2일 소요 (관할 지역 택배사 사정에 따라 추가 소요될 수 있음)
-
-	천재지변, 물량 급증, 수급 변동 등 예외적인 사유 발생 시, 배송이 지연될 수 있는 점 양해 부탁드립니다.
-	군부대 일부와 해외의 경우 배송이 어려울 수 있습니다
-	
-	평일 낮 12시 이전 결제 시 : 당일 출고 (주말 및 공휴일 제외)
-	평일 낮 12시 이후 결제 시 : 다음날 출고 (주말 및 공휴일 제외)`;
-
-	const returnInfo = `교환/반품 안내
-	- 단순 변심에 의한 교환 / 반품은 제품 수량 후 7일까지 가능하며 왕복 배송비는 고객부담입니다.
-	- 상세주소 미입력, 주소지 오기재 등으로 인해 상품이 반송될 경우 왕복 배송비는 고객 부담입니다.
-	- 고객 사유로 인한 교환/반품/반송 시 왕복 배송비 5,000원이 발생하며 제주 및 도서산간 지역의 경우 실제 왕복 배송비가 부과됩니다.
-	- 상품 불량 및 오배송 등으로 인한 귀책 사유가 있을 경우, 교환/반품 배송비는 와이즐리가 부담합니다.
-	
-	교환/반품 제한사항
-	- 고객의 사용, 시간경과, 제품 소비에 의해 제품의 가치가 현저히 감소한 경우
-	- 구성품의 분실, 누락, 파손 혹은 포장이 훼손되어 제품의 가치가 현저히 감소한 경우`;
-
-	const ProductInfo = `상품 유형
-	건강기능식품
-
-	유통기한
-	${lists.expiration} 까지
-
-	영양 정보
-	- 용량 : ${lists.capacity}정 (${lists.capacity / lists.servingSize}일)
-	- 영양성분 : ${
-		lists &&
-		lists?.nutritionFacts.map((fact) => ` ${fact.ingredient} (${fact.volume})`)
-	}
-	- 1일 섭취량: 1회 ${lists.servingSize}정
-
-	섭취 방법
-	1일 1회, 1회 ${lists.servingSize}캡슐을 충분한 물과 함께 섭취하십시오.
-
-	섭취 시 주의사항
-	- 질환이 있거나 의약품 복용 시 전문가와 상담하십시오.
-	- 알레르기 체질 등은 개인에 따라 과민반응을 나타낼 수 있습니다.
-	- 이상사례 발생 시 섭취를 중단하고 전문가와 상담하십시오.
-	- 어린이가 함부로 섭취하지 않도록 일일섭취량 방법을 지도하십시오.
-	- 강력방습제(실리카겔)는 섭취하지 마십시오.
-
-	보관 방법
-	- 수분 및 열에 의해 품질에 영향을 받을 수 있으므로 직사광선을 피해 서늘한 곳에 보관하시고, 어린이 손에 닿지 않는 곳에 보관하십시오.
-- 충격에 제품이 깨질 수 있으니 주의하십시오.
-
-	`;
-
 	if (isLoading) {
 		return <div>Loading...</div>;
 	}
@@ -121,15 +74,20 @@ function Detail() {
 					<Image src={lists.descriptionImage} alt="상품 상세사진" />
 					<InfoContainer>
 						<InfoTitle>상품정보</InfoTitle>
-						<InfoContent>{ProductInfo}</InfoContent>
+						<ProductInfo
+							expiration={lists.expiration}
+							capacity={lists.capacity}
+							servingSize={lists.servingSize}
+							nutritionFacts={lists.nutritionFacts}
+						/>
 					</InfoContainer>
 					<InfoContainer>
 						<InfoTitle>배송정보</InfoTitle>
-						<InfoContent>{deliveryInfo}</InfoContent>
+						<DeliveryInfo />
 					</InfoContainer>
 					<InfoContainer>
 						<InfoTitle>교환 및 반품정보</InfoTitle>
-						<InfoContent>{returnInfo}</InfoContent>
+						<ReturnInfo />
 					</InfoContainer>
 					<Notes>
 						<InfoTitle>Review</InfoTitle>

--- a/client/src/pages/MyPages/NormalOrder.js
+++ b/client/src/pages/MyPages/NormalOrder.js
@@ -15,7 +15,11 @@ function NormalOrder() {
 	);
 
 	if (isLoading) {
-		return <LoadingSpinner />;
+		return (
+			<ListContainer>
+				<LoadingSpinner />
+			</ListContainer>
+		);
 	}
 
 	if (isError) {
@@ -47,7 +51,9 @@ const ListContainer = styled.main`
 	border-radius: 10px;
 	background-color: white;
 	box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.05);
-	width: 100%;
+	width: 864px;
+	min-height: 200px;
+	position: relative;
 
 	& > {
 		:last-child {
@@ -57,7 +63,6 @@ const ListContainer = styled.main`
 `;
 
 const Nolists = styled.div`
-	height: 200px;
 	display: flex;
 	justify-content: center;
 	align-items: center;

--- a/client/src/pages/MyPages/SubscriptionOrder.js
+++ b/client/src/pages/MyPages/SubscriptionOrder.js
@@ -50,7 +50,9 @@ const ListContainer = styled.main`
 	border-radius: 10px;
 	background-color: white;
 	box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.05);
-	width: 100%;
+	width: 864px;
+	min-height: 200px;
+	position: relative;
 
 	& > {
 		:last-child {


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #192 #209

<br>

## 무엇이 추가 되었나요?
### 상세페이지
- **/pages/Detail.js**에 있던 상품 정보, 배송 정보, 교환 및 환불 정보를 **/components/Etc/ItemDetailInfo.js** 로 컴포넌트 분리하였습니다.
- 별점을 클릭할 경우, 하단의 리뷰란으로 스크롤 이동하도록 구현하였습니다.
- 토크를 여닫을 수 있도록 구현하였으며, 여닫을 때 애니메이션 효과를 추가하였습니다.

<br>

## 기타 정보

> 별점 클릭 시 스크롤 이동

![스크롤주륵](https://user-images.githubusercontent.com/107875909/205710129-3c4ab093-bd76-498a-b428-8c925a67ff32.gif)

<br><br>

> 토크 여닫기 +애니메이션

![토크여닫](https://user-images.githubusercontent.com/107875909/205710126-70bfc88e-052e-4487-8cb4-7f5d4b4328aa.gif)


<br>
