### PR TITLE
[Client] 타입스크립트 리팩터링 - useFetch, usePurchase

### DIFF
--- a/client/src/components/Caroucel/CardCaroucel.tsx
+++ b/client/src/components/Caroucel/CardCaroucel.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import './slick.css';
 import './slick-theme.css';
 import { IoIosArrowBack } from 'react-icons/io';
-import MainListCard from '../Lists/MainListCard';
+import MainListCard from '../Cards/MainListCard';
 import { CustomArrow, CardItem } from '../../types/main.type';
 
 const ArrowButton = styled.button<CustomArrow>`

--- a/client/src/components/Etc/Price.tsx
+++ b/client/src/components/Etc/Price.tsx
@@ -10,7 +10,7 @@ import { PriceProps, SummaryPriceProps } from '../../types/price.type';
 function Price({
 	nowPrice,
 	beforePrice,
-	discountRate, // 할인율이 ~%로 문자열로 들어와야 합니다.
+	discountRate,
 	isTotal, // 총액인지
 	quantity, // 수량
 	minus, // 앞에 -가 붙는 지 (결제 정보!)
@@ -49,7 +49,7 @@ function Price({
 export function SummaryPrice({
 	nowPrice,
 	beforePrice,
-	discountRate, // 할인율이 ~%로 문자열로 들어와야 합니다.
+	discountRate,
 	fontSize,
 	fontWeight,
 }: SummaryPriceProps) {
@@ -64,7 +64,7 @@ export function SummaryPrice({
 					<BeforePrice className="beforeDiscounted summary">
 						{`${Number(beforePrice).toLocaleString('ko-KR')}원`}
 					</BeforePrice>
-					<Percent className="summary">{discountRate}</Percent>
+					<Percent className="summary">{`${discountRate}%`}</Percent>
 				</BeforeContainer>
 			)}
 			<div>{`${Number(nowPrice).toLocaleString('ko-KR')}원`}</div>

--- a/client/src/hooks/useFetch.tsx
+++ b/client/src/hooks/useFetch.tsx
@@ -1,14 +1,9 @@
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { useState } from 'react';
+import { AxiosResponse } from 'axios';
 import axiosInstance from '../utils/axiosInstance';
 
-// export const fetchData = async (url) => {
-// 	const { data } = await axiosInstance.get(url).json();
-
-// 	return data.data;
-// };
-
-export const useGet = (url, keyValue) => {
+export const useGet = (url: string, keyValue: string) => {
 	const { isLoading, isError, isSuccess, data, error, refetch } = useQuery(
 		[keyValue],
 		() => axiosInstance.get(url),
@@ -17,12 +12,12 @@ export const useGet = (url, keyValue) => {
 	return { isLoading, isError, isSuccess, data, error, refetch };
 };
 
-export const usePost = (url) => {
+export function usePost<T extends object, K = void>(url: string) {
 	const queryClient = useQueryClient();
-	const [response, setResponse] = useState(null);
+	const [response, setResponse] = useState<AxiosResponse | null>(null);
 
 	const { mutate, isLoading, isError, error } = useMutation(
-		(data) => axiosInstance.post(url, data),
+		(data: T | K) => axiosInstance.post(url, data),
 		{
 			onSuccess: async (res) => {
 				setResponse(res);
@@ -32,11 +27,11 @@ export const usePost = (url) => {
 	);
 
 	return { mutate, isLoading, isError, error, response };
-};
+}
 
-export const useDelete = (url) => {
+export const useDelete = (url: string) => {
 	const queryClient = useQueryClient();
-	const [response, setResponse] = useState(null);
+	const [response, setResponse] = useState<AxiosResponse | null>(null);
 
 	const { mutate, isLoading, isError, error } = useMutation(
 		() => axiosInstance.delete(url),
@@ -51,12 +46,12 @@ export const useDelete = (url) => {
 	return { mutate, isLoading, isError, error, response };
 };
 
-export const usePatch = (url) => {
+export function usePatch<T extends object, K = void>(url: string) {
 	const queryClient = useQueryClient();
-	const [response, setResponse] = useState(null);
+	const [response, setResponse] = useState<AxiosResponse | null>(null);
 
 	const { mutate, isLoading, isError, error } = useMutation(
-		(data) => axiosInstance.patch(url, data),
+		(data: T | K) => axiosInstance.patch(url, data),
 		{
 			onSuccess: (res) => {
 				setResponse(res);
@@ -66,4 +61,4 @@ export const usePatch = (url) => {
 	);
 
 	return { mutate, isLoading, isError, error, response };
-};
+}

--- a/client/src/hooks/useFetch.tsx
+++ b/client/src/hooks/useFetch.tsx
@@ -12,14 +12,14 @@ export function useGet(url: string, keyValue: string) {
 	return { isLoading, isError, isSuccess, data, error, refetch };
 }
 
-export function usePost<T extends object, K = void>(url: string) {
+export function usePost<T extends object, M = void>(url: string) {
 	const queryClient = useQueryClient();
 	const [response, setResponse] = useState<AxiosResponse | null>(null);
 
 	const { mutate, isLoading, isError, error } = useMutation(
-		(data: T | K) => axiosInstance.post(url, data),
+		(data: T | M) => axiosInstance.post(url, data),
 		{
-			onSuccess: async (res) => {
+			onSuccess: (res) => {
 				setResponse(res);
 				queryClient.invalidateQueries();
 			},
@@ -36,7 +36,7 @@ export function useDelete(url: string) {
 	const { mutate, isLoading, isError, error } = useMutation(
 		() => axiosInstance.delete(url),
 		{
-			onSuccess: async (res) => {
+			onSuccess: (res) => {
 				setResponse(res);
 				queryClient.invalidateQueries();
 			},
@@ -46,12 +46,12 @@ export function useDelete(url: string) {
 	return { mutate, isLoading, isError, error, response };
 }
 
-export function usePatch<T extends object, K = void>(url: string) {
+export function usePatch<T extends object, M = void>(url: string) {
 	const queryClient = useQueryClient();
 	const [response, setResponse] = useState<AxiosResponse | null>(null);
 
 	const { mutate, isLoading, isError, error } = useMutation(
-		(data: T | K) => axiosInstance.patch(url, data),
+		(data: T | M) => axiosInstance.patch(url, data),
 		{
 			onSuccess: (res) => {
 				setResponse(res);

--- a/client/src/hooks/useFetch.tsx
+++ b/client/src/hooks/useFetch.tsx
@@ -3,14 +3,14 @@ import { useState } from 'react';
 import { AxiosResponse } from 'axios';
 import axiosInstance from '../utils/axiosInstance';
 
-export const useGet = (url: string, keyValue: string) => {
+export function useGet(url: string, keyValue: string) {
 	const { isLoading, isError, isSuccess, data, error, refetch } = useQuery(
 		[keyValue],
 		() => axiosInstance.get(url),
 	);
 
 	return { isLoading, isError, isSuccess, data, error, refetch };
-};
+}
 
 export function usePost<T extends object, K = void>(url: string) {
 	const queryClient = useQueryClient();
@@ -29,7 +29,7 @@ export function usePost<T extends object, K = void>(url: string) {
 	return { mutate, isLoading, isError, error, response };
 }
 
-export const useDelete = (url: string) => {
+export function useDelete(url: string) {
 	const queryClient = useQueryClient();
 	const [response, setResponse] = useState<AxiosResponse | null>(null);
 
@@ -44,7 +44,7 @@ export const useDelete = (url: string) => {
 	);
 
 	return { mutate, isLoading, isError, error, response };
-};
+}
 
 export function usePatch<T extends object, K = void>(url: string) {
 	const queryClient = useQueryClient();

--- a/client/src/hooks/usePurchase.tsx
+++ b/client/src/hooks/usePurchase.tsx
@@ -3,14 +3,21 @@ import { toast } from 'react-toastify';
 import { useMutation, useQueryClient } from 'react-query';
 import axiosInstance from '../utils/axiosInstance';
 
-function usePurchase(url, params) {
+interface UsePurchaseProps {
+	itemId: number;
+	quantity: number;
+	period: number;
+	subscription: boolean;
+}
+
+const usePurchase = (url: string, params: string) => {
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
 
 	const { mutate, isLoading, isSuccess, isError } = useMutation(
-		(data) => axiosInstance.post(url, data), // .then((res) => setResponse(res))
+		(data: UsePurchaseProps) => axiosInstance.post(url, data),
 		{
-			onSuccess: (res) => {
+			onSuccess: async (res) => {
 				navigate(`/pay/${params}`, { state: res.data.data }); // 결제 페이지로 응답 전송
 				queryClient.invalidateQueries();
 			},
@@ -27,6 +34,6 @@ function usePurchase(url, params) {
 	);
 
 	return { mutate, isLoading, isSuccess, isError };
-}
+};
 
 export default usePurchase;

--- a/client/src/hooks/usePurchase.tsx
+++ b/client/src/hooks/usePurchase.tsx
@@ -10,7 +10,7 @@ interface UsePurchaseProps {
 	subscription: boolean;
 }
 
-const usePurchase = (url: string, params: string) => {
+export default function usePurchase(url: string, params: string) {
 	const queryClient = useQueryClient();
 	const navigate = useNavigate();
 
@@ -34,6 +34,4 @@ const usePurchase = (url: string, params: string) => {
 	);
 
 	return { mutate, isLoading, isSuccess, isError };
-};
-
-export default usePurchase;
+}

--- a/client/src/types/button.type.ts
+++ b/client/src/types/button.type.ts
@@ -35,7 +35,7 @@ export interface PriceButtonProps {
 }
 
 export interface WishlistBtnProps {
-	isChecked: boolean;
+	isChecked: boolean | number;
 	itemId: number;
 	setIsChecked?: (isChecked: number) => void;
 }

--- a/client/src/types/price.type.ts
+++ b/client/src/types/price.type.ts
@@ -1,7 +1,7 @@
 export interface SummaryPriceProps {
 	nowPrice: number;
-	beforePrice?: number;
-	discountRate?: number;
+	beforePrice?: number | boolean;
+	discountRate?: number | boolean;
 	fontSize?: string;
 	fontWeight?: string;
 }


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #278

<br>

## 무엇이 추가 되었나요?
- useFetch에 타입스크립트 적용하였습니다.
- usePurchase에 타입스크립트 적용하였습니다.
- CardCaroucel에서 MainListCard import 경로가 달라 생기는 에러 해결하였습니다.
- 찜 버튼, 가격 컴포넌트의 인자 타입 수정하였습니다.
<br>

## 기타 정보
```ts
export function usePost<T extends object, K = void>(url: string) {
  ...
}

export function usePatch<T extends object, K = void>(url: string) {
  ...
}
```

현재 useFetch.tsx 내부의 `usePost`와 `usePatch`에 동일한 `<T extends object, K = void>` 타입이 적용되어
중복 코드를 없애고자 타입으로 선언하였습니다.

```ts
type UseFetchData<T extends object, K = void> = (data: T | K) => void;
```

근데 요거를 붙이면 에러가 납니다.. 이거 적용하는 법 아시는 분 나중에 적용해주심 감사하겠습니다...

<br>
