### PR TITLE
[Client] 타입스크립트 리팩터링 - 상세 페이지, disCountPrice ⇒ discountPrice 변경, 장바구니 에러 수정 외

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -5,10 +5,7 @@
 		<link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="theme-color" content="#000000" />
-		<meta
-			name="description"
-			content="Web site created using create-react-app"
-		/>
+		<meta name="description" content="With Pillivery Subscribe Health" />
 		<title>Pillivery</title>
 	</head>
 	<body>

--- a/client/src/components/Etc/PayItemInformation.tsx
+++ b/client/src/components/Etc/PayItemInformation.tsx
@@ -23,7 +23,7 @@ export default function PayItemInformation({
 						brand={orderedItem.item.brand}
 						thumbnail={orderedItem.item.thumbnail}
 						title={orderedItem.item.title}
-						price={orderedItem.item.disCountPrice}
+						price={orderedItem.item.discountPrice}
 						capacity={orderedItem.item.capacity}
 						quantity={orderedItem.quantity}
 						beforePrice={orderedItem.item.price}

--- a/client/src/components/Lists/DetailReviewList.tsx
+++ b/client/src/components/Lists/DetailReviewList.tsx
@@ -7,6 +7,7 @@ import OrderDetailList from './MyPageLists/OrderDetailList';
 import ReviewModal from '../Modals/ReviewModal';
 import DeleteNotesModal from '../Modals/DeleteNotesModal';
 import { useDelete } from '../../hooks/useFetch';
+import { DetailReviewListProps } from '../../types/note.type';
 
 function DetailReviewList({
 	star,
@@ -15,7 +16,7 @@ function DetailReviewList({
 	content,
 	review,
 	userId,
-}) {
+}: DetailReviewListProps) {
 	const [openForm, setOpenForm] = useState(false);
 	const [openDeleteModal, setOpenDeleteModal] = useState(false);
 	const user = localStorage.getItem('userId');

--- a/client/src/components/Lists/DetailTalkList.tsx
+++ b/client/src/components/Lists/DetailTalkList.tsx
@@ -9,25 +9,25 @@ import { DotDate } from '../Etc/ListDate';
 import TalkForm from '../Forms/TalkForm';
 import DeleteNotesModal from '../Modals/DeleteNotesModal';
 import { usePost, usePatch, useDelete } from '../../hooks/useFetch';
+import { DetailTalkListProps } from '../../types/note.type';
+import { RootState } from '../../redux/store/store';
 
 function DetailTalkList({
 	isReply,
 	itemId,
 	createdAt,
-	reTalkContent,
 	content,
 	talkId,
 	userId,
-	talkCommentId,
 	displayName,
 	shopper,
-}) {
+}: DetailTalkListProps) {
 	const [writable, setWritable] = useState(false);
 	const [writeReply, setWriteReply] = useState(false);
 	const [openDeleteModal, setOpenDeleteModal] = useState(false);
-	const [newContent, setNewContent] = useState(content || reTalkContent); // 업데이트할 토크 컨텐츠
+	const [newContent, setNewContent] = useState(content); // 업데이트할 토크 컨텐츠
 	const [reContent, setReContent] = useState(''); // 새로 작성한 리토크
-	const { loginStatus } = useSelector((store) => store.user);
+	const { loginStatus } = useSelector((store: RootState) => store.user);
 	const user = localStorage.getItem('userId');
 	const [isAuthor] = useState(Number(user) === userId);
 
@@ -38,9 +38,7 @@ function DetailTalkList({
 	const { mutate: talkDeleteMu } = useDelete(`/talks/${talkId}`);
 
 	// 리토크 삭제
-	const { mutate: reTalkDeleteMu } = useDelete(
-		`/talks/comments/${talkCommentId}`,
-	);
+	const { mutate: reTalkDeleteMu } = useDelete(`/talks/comments/${talkId}`);
 
 	// 리토크 작성
 	const { mutate: reTalkCreateMu } = usePost(
@@ -48,25 +46,25 @@ function DetailTalkList({
 	);
 
 	// 리토크 수정
-	const { mutate: reTalkUpdateMu } = usePatch(
-		`/talks/comments/${talkCommentId}`,
-	);
+	const { mutate: reTalkUpdateMu } = usePatch(`/talks/comments/${talkId}`);
 
 	// 토크 수정 컨텐츠 상태
-	const handleNewContent = useCallback(
-		(e) => {
-			setNewContent(e.target.value);
-		},
-		[newContent],
-	);
+	const handleNewContent: React.ChangeEventHandler<HTMLTextAreaElement> =
+		useCallback(
+			(e) => {
+				setNewContent(e.target.value);
+			},
+			[newContent],
+		);
 
 	// 리톡 작성 컨텐츠 상태
-	const handleReContent = useCallback(
-		(e) => {
-			setReContent(e.target.value);
-		},
-		[reContent],
-	);
+	const handleReContent: React.ChangeEventHandler<HTMLTextAreaElement> =
+		useCallback(
+			(e) => {
+				setReContent(e.target.value);
+			},
+			[reContent],
+		);
 
 	// 리토크 작성! (답글)
 	const handleReTalkCreate = useCallback(() => {
@@ -95,20 +93,21 @@ function DetailTalkList({
 		setWritable(false);
 	}, [newContent]);
 
-	const handleFormOpen = useCallback(
-		(e) => {
-			if (!loginStatus) {
-				toast.error('로그인이 필요한 서비스입니다.');
-				return;
-			}
-			if (e.target.innerText === '수정') {
-				setWritable(!writable); // 수정을 눌렀을 때
-			} else {
-				setWriteReply(!writeReply); // 답변작성을 눌렀을 때
-			}
-		},
-		[writable, writeReply],
-	);
+	const handleFormOpen: React.MouseEventHandler<HTMLButtonElement> =
+		useCallback(
+			(e) => {
+				if (!loginStatus) {
+					toast.error('로그인이 필요한 서비스입니다.');
+					return;
+				}
+				if (e.currentTarget.innerText === '수정') {
+					setWritable(!writable); // 수정을 눌렀을 때
+				} else {
+					setWriteReply(!writeReply); // 답변작성을 눌렀을 때
+				}
+			},
+			[writable, writeReply],
+		);
 
 	const handleDeleteClick = useCallback(() => {
 		setOpenDeleteModal(true);
@@ -159,7 +158,7 @@ function DetailTalkList({
 				) : (
 					<Talk>{newContent}</Talk>
 				)}
-				<InfoContainer className={isReply && 'reply'}>
+				<InfoContainer className={isReply ? 'reply' : ''}>
 					{!isReply && !writable && (
 						<LetterButton onClick={handleFormOpen}>답변 작성</LetterButton>
 					)}

--- a/client/src/components/Lists/MyPageLists/CartList.tsx
+++ b/client/src/components/Lists/MyPageLists/CartList.tsx
@@ -113,7 +113,7 @@ function CartList({ data, item, sub }: CartListProps) {
 							{item.title}
 						</Info>
 						<Price
-							nowPrice={item.disCountPrice}
+							nowPrice={item.discountPrice}
 							beforePrice={item.price}
 							discountRate={item.discountRate}
 						/>
@@ -128,7 +128,7 @@ function CartList({ data, item, sub }: CartListProps) {
 							/>
 						</QuantityContainer>
 						<Price // 가격 * 수량
-							nowPrice={item.disCountPrice}
+							nowPrice={item.discountPrice}
 							quantity={data.quantity}
 							fontSize="20px"
 							fontWeight="extraBold"

--- a/client/src/components/Lists/MyPageLists/SubManagementList.js
+++ b/client/src/components/Lists/MyPageLists/SubManagementList.js
@@ -90,7 +90,7 @@ function SubManagementList({ subManageData }) {
 							{subManageData.item.title}
 						</Info>
 						<Price
-							nowPrice={subManageData.item.disCountPrice}
+							nowPrice={subManageData.item.discountPrice}
 							quantity={1}
 							discountRate={subManageData.item.discountRate}
 							beforePrice={subManageData.item.price}
@@ -109,7 +109,7 @@ function SubManagementList({ subManageData }) {
 							/>
 						</QuantityContainer>
 						<Price // 가격 * 수량
-							nowPrice={subManageData.item.disCountPrice}
+							nowPrice={subManageData.item.discountPrice}
 							quantity={subManageData.quantity} // 수량!
 							fontSize="20px"
 							fontWeight="extraBold"

--- a/client/src/components/Modals/TalkModal.js
+++ b/client/src/components/Modals/TalkModal.js
@@ -63,11 +63,11 @@ function TalkModal({ setIsOpen, modalIsOpen, talk }) {
 					title={talk?.item.title}
 					capacity={talk?.item.capacity}
 					itemId={talk?.item.itemId}
-					price={talk.item.disCountPrice || talk.item.price}
+					price={talk.item.discountPrice || talk.item.price}
 					discountRate={
 						talk.item.discountRate === 0 ? '' : talk.item.discountRate
 					}
-					beforePrice={talk.item.disCountPrice ? talk.item.price : null}
+					beforePrice={talk.item.discountPrice ? talk.item.price : null}
 				/>
 			}
 			form={

--- a/client/src/pages/Carts/SubCart.tsx
+++ b/client/src/pages/Carts/SubCart.tsx
@@ -20,7 +20,7 @@ function SubCart() {
 		data: items,
 		error,
 	} = useQuery<AxiosResponse<CartData>>([pathname], () =>
-		axiosInstance.get('/carts?subscription=ture'),
+		axiosInstance.get('/carts?subscription=true'),
 	);
 
 	const { mutate: purchaseMutate } = usePurchase(

--- a/client/src/pages/Detail.js
+++ b/client/src/pages/Detail.js
@@ -1,6 +1,6 @@
 import styled, { keyframes, css } from 'styled-components';
 import { useLocation, useParams } from 'react-router-dom';
-import { useCallback, useState, useRef } from 'react';
+import { useCallback, useState, useRef, Fragment } from 'react';
 import { toast } from 'react-toastify';
 import { IoIosArrowBack } from 'react-icons/io';
 import Summary from '../components/ItemSummary/Summary';
@@ -70,6 +70,7 @@ function Detail() {
 		[content],
 	);
 	const lists = !isLoading && data.data.data;
+
 	if (isLoading) {
 		return (
 			<DetailContainer className="loading">
@@ -166,7 +167,7 @@ function Detail() {
 						<ListsContainer className="talk">
 							{lists.talks.data.length !== 0 ? (
 								lists.talks.data.map((talk) => (
-									<>
+									<Fragment key={talk.talkId}>
 										<DetailTalkList
 											key={talk.talkId}
 											itemId={talk.itemId}
@@ -178,21 +179,19 @@ function Detail() {
 											displayName={talk.displayName}
 										/>
 										{talk.talkComments &&
-											talk.talkComments.map((retalk) => {
-												return (
-													<DetailTalkList
-														key={`${retalk.talkCommentId.toString()}-retalk`}
-														talkCommentId={retalk.talkCommentId}
-														reTalkContent={retalk.content}
-														createdAt={retalk.createdAt}
-														shopper={retalk.shopper}
-														displayName={retalk.displayName}
-														userId={retalk.userId}
-														isReply
-													/>
-												);
-											})}
-									</>
+											talk.talkComments.map((retalk) => (
+												<DetailTalkList
+													key={retalk.talkCommentId}
+													talkCommentId={retalk.talkCommentId}
+													reTalkContent={retalk.content}
+													createdAt={retalk.createdAt}
+													shopper={retalk.shopper}
+													displayName={retalk.displayName}
+													userId={retalk.userId}
+													isReply
+												/>
+											))}
+									</Fragment>
 								))
 							) : (
 								<NoNote>작성된 토크가 없습니다.</NoNote>
@@ -201,7 +200,7 @@ function Detail() {
 					</Notes>
 				</Contents>
 				<SummaryContainer>
-					<Summary
+					<ItemSummary
 						itemId={lists.itemId}
 						name={lists.title}
 						brand={lists.brand}

--- a/client/src/pages/MyPages/NoteReview.tsx
+++ b/client/src/pages/MyPages/NoteReview.tsx
@@ -41,11 +41,11 @@ function NoteReview() {
 							thumbnail={list.item.thumbnail}
 							title={list.item.title}
 							capacity={list.item.capacity}
-							nowPrice={list.item.disCountPrice || list.item.price}
+							nowPrice={list.item.discountPrice || list.item.price}
 							discountRate={
 								list.item.discountRate === 0 ? '' : list.item.discountRate
 							}
-							beforePrice={list.item.disCountPrice ? list.item.price : null}
+							beforePrice={list.item.discountPrice ? list.item.price : null}
 						/>
 					))
 				)}

--- a/client/src/pages/MyPages/OrderDetail.js
+++ b/client/src/pages/MyPages/OrderDetail.js
@@ -52,11 +52,11 @@ function OrderDetail() {
 							thumbnail={list.item.thumbnail}
 							title={list.item.title}
 							quantity={list.quantity}
-							nowPrice={list.item.disCountPrice || list.item.price}
+							nowPrice={list.item.discountPrice || list.item.price}
 							discountRate={
 								list.item.discountRate === 0 ? '' : list.item.discountRate
 							}
-							beforePrice={list.item.disCountPrice ? list.item.price : null}
+							beforePrice={list.item.discountPrice ? list.item.price : null}
 							period={list.period}
 							subscription={list.subscription}
 							capacity={list.item.capacity}

--- a/client/src/types/form.type.ts
+++ b/client/src/types/form.type.ts
@@ -12,5 +12,5 @@ export interface DefaultFormProps extends BasicFormProps {
 }
 
 export interface TalkFormProps extends BasicFormProps {
-	placeholder: string;
+	placeholder?: string;
 }

--- a/client/src/types/item.type.ts
+++ b/client/src/types/item.type.ts
@@ -1,7 +1,7 @@
 export interface ItemShortcutData {
 	brand: string;
 	capacity: number;
-	disCountPrice: number;
+	discountPrice: number;
 	discountRate: number;
 	itemId: number;
 	price: number;

--- a/client/src/types/item.type.ts
+++ b/client/src/types/item.type.ts
@@ -39,3 +39,8 @@ export interface CartItemWithData {
 	createdAt: Date;
 	updatedAt: Date;
 }
+
+export interface NutritionFact {
+	ingredient: string;
+	volume: string;
+}

--- a/client/src/types/itemList.type.ts
+++ b/client/src/types/itemList.type.ts
@@ -1,9 +1,4 @@
-import { ItemShortcutData } from './item.type';
-
-export interface NutritionFact {
-	ingredient: string;
-	volume: string;
-}
+import { ItemShortcutData, NutritionFact } from './item.type';
 
 export interface Item extends ItemShortcutData {
 	content: string;

--- a/client/src/types/main.type.ts
+++ b/client/src/types/main.type.ts
@@ -1,5 +1,5 @@
 import { CustomArrowProps } from 'react-slick';
-import { NutritionFact } from './itemList.type';
+import { NutritionFact } from './item.type';
 
 export interface CardItem {
 	itemId: number;

--- a/client/src/types/note.type.ts
+++ b/client/src/types/note.type.ts
@@ -91,8 +91,44 @@ interface TalkComments extends NoteCommonEl {
 // 상세페이지 리뷰, 토크, 토크코멘트 공통 요소
 interface NoteCommonEl {
 	content: string;
-	createAt: string;
 	displayName: string;
-	updateAt: string;
+	createdAt: Date;
+	updatedAt: Date;
 	userId: number;
+}
+
+// 상세페이지 리뷰 목록에 전달할 Props 타입
+export interface DetailReviewListProps extends Omit<NoteCommonEl, 'updatedAt'> {
+	star: number;
+	itemId: number;
+	review: {
+		item: ReviewItem;
+	};
+}
+
+interface ReviewItem {
+	reviewId: number;
+	userId: number;
+	itemId: number;
+	content: string;
+	brand: string;
+	thumbnail: string;
+	title: string;
+	capacity: number;
+	nowPrice: number;
+	discountRate: number | '';
+	beforePrice: number | null;
+	star: number;
+}
+
+// 상세페이지 토크 목록에 전달할 Props 타입
+export interface DetailTalkListProps {
+	talkId: number;
+	content: string;
+	createdAt: Date;
+	displayName: string;
+	userId: number;
+	itemId: number;
+	shopper: boolean;
+	isReply?: boolean;
 }

--- a/client/src/types/note.type.ts
+++ b/client/src/types/note.type.ts
@@ -58,3 +58,41 @@ export interface MyPageTalkListProps {
 	talk: NoteTalkItemWithData;
 	isReply: boolean;
 }
+
+// 상세페이지 리뷰
+export interface DetailReviewsData {
+	data: Reviews[];
+	pageInfo: PageInfo;
+}
+
+interface Reviews extends NoteCommonEl {
+	itemId: number;
+	reviewId: number;
+	star: number;
+}
+
+export interface DetailTalksData {
+	data: Talks[];
+	pageInfo: PageInfo;
+}
+
+interface Talks extends NoteCommonEl {
+	itemId: number;
+	shopper: boolean;
+	talkComments: TalkComments[];
+	talkId: number;
+}
+
+interface TalkComments extends NoteCommonEl {
+	shopper: boolean;
+	talkCommentId: number;
+}
+
+// 상세페이지 리뷰, 토크, 토크코멘트 공통 요소
+interface NoteCommonEl {
+	content: string;
+	createAt: string;
+	displayName: string;
+	updateAt: string;
+	userId: number;
+}


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #289 #290 #292

<br>

## 무엇이 추가 되었나요?
- api 응답 데이터 필드명 변경에 따라, Client 파일에 있는 모든 `disCountPrice` 코드를  `discountPrice`로 변경하였습니다.
- 상세페이지에서 나타나던 **key prop 관련 에러** 해결하였습니다.
- 링크 공유 시 나타나는 사이트 설명을 변경하기 위해 index.html의 `description` 관련 `meta` 태그 변경하였습니다.
  - 기존 설명: Web site created using create-react-app
  - 변경 후: With Pillivery Subscribe Health
- interface `NutritionFact` 선언 위치를 itemList.type.ts ⇒ item.type.ts 로 변경하였습니다.
- 상세 페이지에 전반적으로 타입스크립트 적용하였습니다.
- 장바구니에서 발생하는 400 Bad Request 에러 해결하였습니다. (GET 요청 URL 오타 수정)

<br>

## 기타 정보
수정 전 링크 공유 모습입니다 너므나 당당하게 CRA로 만들었다구 표출 중... . 

<img width="431" alt="스크린샷 2023-03-30 오후 9 49 57" src="https://user-images.githubusercontent.com/107875909/228841260-6140d582-721c-408e-bf98-b555dbb073bb.png">

<br>

### 📌 혹시 할인가가 NaN으로 표시되는 페이지가 있는 지 확인부탁드립니다!!
이것저것 눌러가면서 확인하긴 했는데 혹시 몰라서욥 , , 

###  로컬에서 장바구니 페이지 접근 잘 되는 지 확인 한번씩만 해주세요!!
전 무한로딩 걸리네엽 ㅠㅠ
<br>
