### PR TITLE
[Client] 마이페이지 - 주문내역 조회 (일반/정기) 무한스크롤 적용

### DIFF
--- a/client/src/apis/itemApis.ts
+++ b/client/src/apis/itemApis.ts
@@ -42,3 +42,18 @@ export const fetchSearchItems = async ({
 		isLast: pageInfo.totalPages <= pageInfo.page,
 	};
 };
+
+// 상세페이지 주문내역 조회
+export const fetchOrderLists = async (pageParam: string) => {
+	const res = await axiosInstance.get(
+		`/orders?subscription=false&page=${pageParam}&size=7`,
+	);
+	const { data } = await res.data;
+	const { pageInfo } = await res.data;
+
+	return {
+		data,
+		nextPage: pageParam + 1,
+		isLast: pageInfo.totalPages <= pageInfo.page,
+	};
+};

--- a/client/src/apis/itemApis.ts
+++ b/client/src/apis/itemApis.ts
@@ -4,6 +4,7 @@ import {
 	InfiniteQueryPromise,
 } from '../types/itemList.type';
 import axiosInstance from '../utils/axiosInstance';
+import { FetchOrderListsProps } from '../types/order.type';
 
 export const fetchCathgoryItems = async ({
 	category,
@@ -44,9 +45,12 @@ export const fetchSearchItems = async ({
 };
 
 // 상세페이지 주문내역 조회
-export const fetchOrderLists = async (pageParam: string) => {
+export const fetchOrderLists = async ({
+	pageParam,
+	isSub,
+}: FetchOrderListsProps): Promise<InfiniteQueryPromise> => {
 	const res = await axiosInstance.get(
-		`/orders?subscription=false&page=${pageParam}&size=7`,
+		`/orders?subscription=${isSub}&page=${pageParam}&size=7`,
 	);
 	const { data } = await res.data;
 	const { pageInfo } = await res.data;

--- a/client/src/components/Etc/Constants.js
+++ b/client/src/components/Etc/Constants.js
@@ -116,3 +116,8 @@ export const MYPAGE_TAB = {
 	],
 	PATH: ['user-info', 'order/normal', 'sub-manage', 'wish', 'note/review'],
 };
+
+export const ERROR_INFORMATION = `현재 정보를 불러올 수 없습니다.
+잠시 후 다시 시도해주세요.`;
+
+export const NO_ORDER_HISTORY = '주문 내역이 없습니다.';

--- a/client/src/hooks/useGetList.ts
+++ b/client/src/hooks/useGetList.ts
@@ -1,5 +1,9 @@
 import { useInfiniteQuery } from 'react-query';
-import { fetchCathgoryItems, fetchSearchItems } from '../apis/itemApis';
+import {
+	fetchCathgoryItems,
+	fetchSearchItems,
+	fetchOrderLists,
+} from '../apis/itemApis';
 import { UseGetList, UseGetSearchList } from '../types/itemList.type';
 
 export const useGetList = ({ pathname, category, path, query }: UseGetList) => {
@@ -24,6 +28,18 @@ export const useGetSearchList = ({
 		pathname,
 		({ pageParam = 1 }) =>
 			fetchSearchItems({ keyword, path, query, pageParam }),
+		{
+			getNextPageParam: ({ isLast, nextPage }) =>
+				!isLast ? nextPage : undefined,
+		},
+	);
+};
+
+// 상세페이지 주문내역조회
+export const useGetOrderList = (pathname: string) => {
+	return useInfiniteQuery(
+		pathname,
+		({ pageParam = 1 }) => fetchOrderLists(pageParam),
 		{
 			getNextPageParam: ({ isLast, nextPage }) =>
 				!isLast ? nextPage : undefined,

--- a/client/src/hooks/useGetList.ts
+++ b/client/src/hooks/useGetList.ts
@@ -5,6 +5,7 @@ import {
 	fetchOrderLists,
 } from '../apis/itemApis';
 import { UseGetList, UseGetSearchList } from '../types/itemList.type';
+import { UseGetOrderListProps } from '../types/order.type';
 
 export const useGetList = ({ pathname, category, path, query }: UseGetList) => {
 	return useInfiniteQuery(
@@ -36,10 +37,10 @@ export const useGetSearchList = ({
 };
 
 // 상세페이지 주문내역조회
-export const useGetOrderList = (pathname: string) => {
+export const useGetOrderList = ({ pathname, isSub }: UseGetOrderListProps) => {
 	return useInfiniteQuery(
 		pathname,
-		({ pageParam = 1 }) => fetchOrderLists(pageParam),
+		({ pageParam = 1 }) => fetchOrderLists({ pageParam, isSub }),
 		{
 			getNextPageParam: ({ isLast, nextPage }) =>
 				!isLast ? nextPage : undefined,

--- a/client/src/pages/MyPages/NormalOrder.js
+++ b/client/src/pages/MyPages/NormalOrder.js
@@ -13,8 +13,10 @@ import { useGetOrderList } from '../../hooks/useGetList';
 function NormalOrder() {
 	const { pathname } = useLocation();
 	const { ref, inView } = useInView();
-	const { data, status, fetchNextPage, isFetchingNextPage } =
-		useGetOrderList(pathname);
+	const { data, status, fetchNextPage, isFetchingNextPage } = useGetOrderList({
+		pathname,
+		isSub: false,
+	});
 
 	// 최하단 div가 보이면 다음 페이지를 불러옴
 	useEffect(() => {
@@ -71,7 +73,7 @@ const ListContainer = styled.main`
 	border-radius: 10px;
 	background-color: white;
 	box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.05);
-	width: 864px;
+	width: 872px;
 	min-height: 200px;
 	position: relative;
 

--- a/client/src/types/order.type.ts
+++ b/client/src/types/order.type.ts
@@ -1,0 +1,9 @@
+export interface UseGetOrderListProps {
+	pathname: string;
+	isSub: boolean;
+}
+
+export interface FetchOrderListsProps {
+	pageParam: number;
+	isSub: boolean;
+}


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #293

<br>

## 무엇이 추가 되었나요?
- 마이페이지 - 주문내역 조회 (일반/정기)에 무한스크롤을 적용하였습니다.
![주문내역무한스크롤적용](https://user-images.githubusercontent.com/107875909/229564638-503bbcf7-74c9-454e-b86f-d08a857f8616.gif)

<br>

## 기타 정보
지금 tsx로 변경하고 타입스크립트까지 적용하면 변경 사항이 너무 많아서, 커밋 히스토리가 날아갈 것 같습니다...
이번 PR 한번 머지하고 리팩터링 진행하도록 하겠습니다!

<br>
