### PR TITLE
[Client] useGet에 제네릭 적용 및 403 에러 처리

### DIFF
--- a/client/src/components/Etc/Constants.js
+++ b/client/src/components/Etc/Constants.js
@@ -121,3 +121,6 @@ export const ERROR_INFORMATION = `현재 정보를 불러올 수 없습니다.
 잠시 후 다시 시도해주세요.`;
 
 export const NO_ORDER_HISTORY = '주문 내역이 없습니다.';
+
+export const TOKEN_EXPIRED_INFOMATION =
+	'로그인이 만료되었습니다. 다시 로그인해주세요.';

--- a/client/src/hooks/useFetch.ts
+++ b/client/src/hooks/useFetch.ts
@@ -1,13 +1,26 @@
+import { useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { useState } from 'react';
-import { AxiosResponse } from 'axios';
+import { AxiosResponse, AxiosError } from 'axios';
+import { toast } from 'react-toastify';
 import axiosInstance from '../utils/axiosInstance';
+import { TOKEN_EXPIRED_INFOMATION } from '../components/Etc/Constants';
 
-export function useGet(url: string, keyValue: string) {
-	const { isLoading, isError, isSuccess, data, error, refetch } = useQuery(
-		[keyValue],
-		() => axiosInstance.get(url),
-	);
+export function useGet<T>(url: string, keyValue: string) {
+	const navigate = useNavigate();
+	const { isLoading, isError, isSuccess, data, error, refetch } = useQuery<
+		AxiosResponse<T>
+	>([keyValue], () => axiosInstance.get(url), {
+		onError: (errRes) => {
+			const { response } = errRes as AxiosError;
+
+			if (response?.status === 403) {
+				localStorage.clear();
+				navigate('/login');
+				toast.error(TOKEN_EXPIRED_INFOMATION);
+			}
+		},
+	});
 
 	return { isLoading, isError, isSuccess, data, error, refetch };
 }


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #296

<br>

## 무엇이 추가 되었나요?
- `useGet`이 받아오는 `data` 타입으로 제네릭 타입 적용하였습니다.
- 토큰 만료 관련 403 에러 발생 시 로컬 스토리지를 비우고, 로그인 화면으로 이동되도록 구현하였습니다.

<br>

## 기타 정보
제 브랜치에서 작업 중인 거 고치려면 한참 남았는데 현수님 작업하시려면 `useGet` 필요하실 것 같아서 임시 브랜치 팠습니다!
해당 PR 머지하고 나면 브랜치 닫도록 하겠습니다

<br>
