### PR TITLE
[Client] 타입스크립트 리팩터링 - 주문내역 조회(일반/정기), 주문내역 상세조회 외

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,6 +30,7 @@ function App() {
 					position="top-center"
 					autoClose={3000}
 					theme="colored"
+					pauseOnFocusLoss={false}
 				/>
 				<ReactQueryDevtools />
 			</QueryClientProvider>

--- a/client/src/apis/itemApis.ts
+++ b/client/src/apis/itemApis.ts
@@ -2,16 +2,17 @@ import {
 	FetchCathgoryItems,
 	FetchSearchItems,
 	InfiniteQueryPromise,
+	Item,
 } from '../types/itemList.type';
 import axiosInstance from '../utils/axiosInstance';
-import { FetchOrderListsProps } from '../types/order.type';
+import { FetchOrderListsProps, OrderListData } from '../types/order.type';
 
 export const fetchCathgoryItems = async ({
 	category,
 	path,
 	query,
 	pageParam,
-}: FetchCathgoryItems): Promise<InfiniteQueryPromise> => {
+}: FetchCathgoryItems): Promise<InfiniteQueryPromise<Item[]>> => {
 	const res = await axiosInstance.get(
 		`/category${path}?categoryName=${category}${query}&page=${pageParam}&size=12`,
 	);
@@ -30,7 +31,7 @@ export const fetchSearchItems = async ({
 	path,
 	query,
 	pageParam,
-}: FetchSearchItems): Promise<InfiniteQueryPromise> => {
+}: FetchSearchItems): Promise<InfiniteQueryPromise<Item[]>> => {
 	const res = await axiosInstance.get(
 		`/search${path}?keyword=${keyword}${query}&page=${pageParam}&size=12`,
 	);
@@ -48,7 +49,7 @@ export const fetchSearchItems = async ({
 export const fetchOrderLists = async ({
 	pageParam,
 	isSub,
-}: FetchOrderListsProps): Promise<InfiniteQueryPromise> => {
+}: FetchOrderListsProps): Promise<InfiniteQueryPromise<OrderListData[]>> => {
 	const res = await axiosInstance.get(
 		`/orders?subscription=${isSub}&page=${pageParam}&size=7`,
 	);

--- a/client/src/components/Buttons/WishlistButton.tsx
+++ b/client/src/components/Buttons/WishlistButton.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { FaHeart } from 'react-icons/fa';
-import { useCallback, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { usePost } from '../../hooks/useFetch';
 import { WishlistBtnProps } from '../../types/button.type';
 
@@ -14,15 +14,21 @@ function WishlistButton({
 	const token = localStorage.getItem('accessToken');
 	const { mutate } = usePost(`/wishes/${itemId}?wish=${request}`);
 
-	const handleHeartClick = useCallback(() => {
+	const handleHeartClick = () => {
 		if (!token && setOpenLoginModal) {
 			setOpenLoginModal(true);
 			return;
 		}
+
 		mutate();
+
 		if (setIsChecked) {
-			setIsChecked(isChecked ? 0 : 1);
+			setIsChecked(!isChecked);
 		}
+	};
+
+	useEffect(() => {
+		setRequest(isChecked ? 0 : 1);
 	}, [isChecked]);
 
 	return (
@@ -37,22 +43,25 @@ function WishlistButton({
 
 const WishBox = styled.div`
 	display: inline-flex;
-	z-index: 99;
-	.red-heart {
-		path {
-			color: #ff555f;
-			opacity: 100%;
-			stroke-width: 0;
-		}
-	}
+	z-index: 2;
+
 	& > svg {
 		font-size: 18px;
+
 		path {
 			cursor: pointer;
 			stroke: var(--gray-300);
 			color: var(--gray-200);
 			stroke-width: 10px;
 			opacity: 30%;
+		}
+	}
+
+	.red-heart {
+		path {
+			color: #ff555f;
+			opacity: 100%;
+			stroke-width: 0;
 		}
 	}
 `;

--- a/client/src/components/Buttons/WishlistButton.tsx
+++ b/client/src/components/Buttons/WishlistButton.tsx
@@ -1,18 +1,22 @@
 import styled from 'styled-components';
 import { FaHeart } from 'react-icons/fa';
 import { useCallback, useState } from 'react';
-import { toast } from 'react-toastify';
 import { usePost } from '../../hooks/useFetch';
 import { WishlistBtnProps } from '../../types/button.type';
 
-function WishlistButton({ isChecked, itemId, setIsChecked }: WishlistBtnProps) {
+function WishlistButton({
+	isChecked,
+	itemId,
+	setIsChecked,
+	setOpenLoginModal,
+}: WishlistBtnProps) {
 	const [request, setRequest] = useState(isChecked ? 0 : 1);
 	const token = localStorage.getItem('accessToken');
 	const { mutate } = usePost(`/wishes/${itemId}?wish=${request}`);
 
 	const handleHeartClick = useCallback(() => {
-		if (!token) {
-			toast.error('로그인이 필요한 서비스입니다.');
+		if (!token && setOpenLoginModal) {
+			setOpenLoginModal(true);
 			return;
 		}
 		mutate();

--- a/client/src/components/ItemSummary/ItemSummary.tsx
+++ b/client/src/components/ItemSummary/ItemSummary.tsx
@@ -1,7 +1,6 @@
 import styled, { keyframes } from 'styled-components';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { toast } from 'react-toastify';
 import WishlistButton from '../Buttons/WishlistButton';
 import Tag from '../Etc/Tag';
 import { BlackButton, WhiteButton } from '../Buttons/BlackButton';
@@ -13,6 +12,7 @@ import CartModal from '../Modals/CartModal';
 import useGetWishes from '../../hooks/useGetWishes';
 import { usePost } from '../../hooks/useFetch';
 import usePurchase from '../../hooks/usePurchase';
+import LoginModal from '../Modals/LoginModal';
 
 interface ItemSummaryProps {
 	name: string;
@@ -45,6 +45,7 @@ function ItemSummary({
 	const [path, setPath] = useState(''); // 바로결제하기 클릭 시, 이동할 페이지
 	const [showOptions, setShowOptions] = useState(false);
 	const [openCartModal, setOpenCartModal] = useState(false);
+	const [openLoginModal, setOpenLoginModal] = useState(false);
 	const token = localStorage.getItem('accessToken');
 	const [orderList, setOrdertList] = useState({
 		quantity: 1,
@@ -117,7 +118,7 @@ function ItemSummary({
 			if (token) {
 				purMu({ ...orderList, itemId });
 			} else {
-				toast.error('로그인이 필요한 서비스입니다.');
+				setOpenLoginModal(true);
 			}
 		}, [orderList]);
 
@@ -127,7 +128,7 @@ function ItemSummary({
 			cartMu({ ...orderList });
 			setOpenCartModal(true);
 		} else {
-			toast.error('로그인이 필요한 서비스입니다.');
+			setOpenLoginModal(true);
 		}
 	}, [orderList]);
 
@@ -140,17 +141,10 @@ function ItemSummary({
 		}
 	}, [orderList]);
 
-	// // 로그인 모달을 띄우는 함수
-	// const handleOpenLoginModal = () => {
-	// 	if (!token) {
-	// 		setOpenLoginModal(true);
-	// 	}
-	// };
-
 	// 로그인 모달 속, 로그인 페이지로 가는 함수
-	// const handleLoginMove = useCallback(() => {
-	// 	navigate('/login');
-	// }, []);
+	const handleLoginMove = useCallback(() => {
+		navigate('/login');
+	}, []);
 
 	return (
 		<Container>
@@ -159,6 +153,7 @@ function ItemSummary({
 					<HeadBox>
 						<p>{brand}</p>
 						<WishlistButton
+							setOpenLoginModal={setOpenLoginModal}
 							setIsChecked={setIsCheckedWish}
 							isChecked={isCheckedWish}
 							itemId={itemId}
@@ -230,6 +225,11 @@ function ItemSummary({
 				openModal={openCartModal}
 				contents="장바구니에 상품이 담겼습니다."
 				onClickPbtn={handleCartClick}
+			/>
+			<LoginModal
+				setIsOpen={setOpenLoginModal}
+				modalIsOpen={openLoginModal}
+				onClickPbtn={handleLoginMove}
 			/>
 		</Container>
 	);

--- a/client/src/components/ItemSummary/ItemSummary.tsx
+++ b/client/src/components/ItemSummary/ItemSummary.tsx
@@ -10,7 +10,8 @@ import { PeriodChoiceTab } from '../Tabs/ToggleTabs';
 import { LongTextStar } from '../Stars/TextStar';
 import Price, { SummaryPrice } from '../Etc/Price';
 import CartModal from '../Modals/CartModal';
-import { usePost, useGet } from '../../hooks/useFetch';
+import useGetWishes from '../../hooks/useGetWishes';
+import { usePost } from '../../hooks/useFetch';
 import usePurchase from '../../hooks/usePurchase';
 
 interface ItemSummaryProps {
@@ -51,7 +52,10 @@ function ItemSummary({
 		subscription: false,
 	});
 
-	const { data: WishData } = useGet('/wishes/item', `detail/wishs`);
+	const { data: WishData } = useGetWishes<{ data: number[] }>(
+		'/wishes/item',
+		`detail/wishs`,
+	);
 	const [isCheckedWish, setIsCheckedWish] = useState(
 		WishData?.data?.data.includes(itemId) ? 1 : 0,
 	);

--- a/client/src/components/ItemSummary/ItemSummary.tsx
+++ b/client/src/components/ItemSummary/ItemSummary.tsx
@@ -1,5 +1,5 @@
 import styled, { keyframes } from 'styled-components';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import WishlistButton from '../Buttons/WishlistButton';
 import Tag from '../Etc/Tag';
@@ -57,17 +57,14 @@ function ItemSummary({
 		'/wishes/item',
 		`detail/wishs`,
 	);
+
 	const [isCheckedWish, setIsCheckedWish] = useState(
-		WishData?.data?.data.includes(itemId) ? 1 : 0,
+		!!WishData?.data?.data.includes(itemId),
 	);
 
 	useEffect(() => {
-		if (WishData?.data?.data.includes(itemId)) {
-			setIsCheckedWish(1);
-		} else {
-			setIsCheckedWish(0);
-		}
-	}, []);
+		setIsCheckedWish(!!WishData?.data?.data.includes(itemId));
+	}, [WishData]);
 
 	const { mutate: cartMu } = usePost(`/carts/${itemId}`);
 	const { mutate: purMu } = usePurchase('/orders/single', path);
@@ -301,7 +298,6 @@ const TagsBox = styled.div`
 const RateBox = styled.div`
 	display: flex;
 	justify-content: space-between;
-	/* align-items: center; */
 	width: 100%;
 	margin-bottom: 10px;
 `;
@@ -309,7 +305,6 @@ const RateBox = styled.div`
 const ButtonBox = styled.div`
 	display: flex;
 	justify-content: space-between;
-	/* width: 100%; */
 `;
 
 const slide = keyframes`

--- a/client/src/components/Lists/MyPageLists/OrderDetailList.tsx
+++ b/client/src/components/Lists/MyPageLists/OrderDetailList.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from 'react-router-dom';
 import { LetterButtonColor } from '../../Buttons/LetterButton';
 import Price from '../../Etc/Price';
 import ReviewModal from '../../Modals/ReviewModal';
+import { OrderDetailListProps } from '../../../types/order.type';
 
 function OrderDetailList({
 	inModal,
@@ -16,14 +17,14 @@ function OrderDetailList({
 	nowPrice,
 	beforePrice,
 	discountRate,
-	itemOrderId, // 주문내역 속 개별아이템 주문id!
+	itemOrderId, // 주문내역 속 개별아이템 주문id
 	capacity,
 	quantity,
 	period,
 	subscription,
 	orderStatus,
 	itemId,
-}) {
+}: OrderDetailListProps) {
 	const [modalIsOpen, setIsOpen] = useState(false);
 	const navigate = useNavigate();
 
@@ -51,12 +52,12 @@ function OrderDetailList({
 	};
 
 	return (
-		<Box className={inModal && 'in-modal'}>
+		<Box inModal={inModal}>
 			<ImageContainer onClick={handlePageMove}>
 				<Image src={thumbnail} alt="상품 이미지" />
 			</ImageContainer>
 			<Wrap>
-				<InformationForm className={subscription && 'subscription'}>
+				<InformationForm subscription={subscription}>
 					<Brand>{brand}</Brand>
 					<Name onClick={handlePageMove}>{`${title}${
 						capacity && `, ${capacity}정`
@@ -69,8 +70,8 @@ function OrderDetailList({
 						{quantity && <Quantity>{quantity}개 / </Quantity>}
 						<Price // 가격 * 수량
 							nowPrice={nowPrice}
-							beforePrice={nowPrice === beforePrice ? null : beforePrice}
-							discountRate={nowPrice === beforePrice ? null : discountRate}
+							beforePrice={nowPrice !== beforePrice && beforePrice}
+							discountRate={nowPrice !== beforePrice && discountRate}
 							fontSize="14px"
 							fontWeight="Bold"
 							quantity={quantity}
@@ -82,7 +83,7 @@ function OrderDetailList({
 						<LetterButtonColor
 							onClick={openModal}
 							color="gray"
-							colorcode="500"
+							colorCode="500"
 							fontSize="13px"
 						>
 							리뷰 쓰기
@@ -101,17 +102,15 @@ function OrderDetailList({
 	);
 }
 
-const Box = styled.div`
+const Box = styled.div<{ inModal?: boolean }>`
 	border-bottom: 1px solid rgb(235, 235, 235);
 	background-color: white;
 	width: 450px;
 	height: 180px;
 	display: flex;
 	align-items: center;
-	padding: 19px;
-	&.in-modal {
-		width: 100%;
-	}
+	padding: 18px 10px 18px 18px;
+	width: ${({ inModal }) => (inModal ? '100%' : '450px')};
 `;
 
 const Wrap = styled.div`
@@ -119,7 +118,7 @@ const Wrap = styled.div`
 	flex-direction: column;
 	margin-left: 20px;
 	width: 100%;
-	position: relative;
+	margin-top: 2px;
 `;
 
 const ImageContainer = styled.div`
@@ -135,11 +134,8 @@ const Image = styled.img`
 	align-items: center;
 `;
 
-const InformationForm = styled.div`
-	margin-bottom: 23px;
-	&.subscription {
-		margin-bottom: 12px;
-	}
+const InformationForm = styled.div<{ subscription: boolean }>`
+	margin-bottom: ${({ subscription }) => (subscription ? '14px' : '23px')};
 `;
 
 const Brand = styled.div`
@@ -164,14 +160,12 @@ const BottomContainer = styled.div`
 const Total = styled.div`
 	display: flex;
 	font-weight: var(--bold);
+	align-items: center;
 `;
 
 const Period = styled.div`
 	color: var(--purple-200);
-	/* position: relative; */
-	margin-bottom: 4px;
-	/* top: -15px; */
-	/* right: 0; */
+	margin-bottom: 5px;
 	font-size: 12px;
 `;
 
@@ -184,9 +178,7 @@ const ReviewContainer = styled.div`
 	align-items: center;
 	cursor: pointer;
 	align-self: end;
-	position: absolute;
-	bottom: -25px;
-	right: -12px;
+	margin-top: 4px;
 	* {
 		color: var(--gray-500);
 	}

--- a/client/src/components/Lists/MyPageLists/OrderList.tsx
+++ b/client/src/components/Lists/MyPageLists/OrderList.tsx
@@ -8,13 +8,12 @@ import { DotDate } from '../../Etc/ListDate';
 import Price from '../../Etc/Price';
 import CancelModal from '../../Modals/CancelModal';
 import { useDelete } from '../../../hooks/useFetch';
+import { OrderListData } from '../../../types/order.type';
 
-function OrderList({ list }) {
+function OrderList({ list }: { list: OrderListData }) {
 	const navigate = useNavigate();
 	const [openCancel, setOpenCancel] = useState(false);
-	const { mutate, isLoading, isError, error, response } = useDelete(
-		`/orders/${list.orderId}`,
-	);
+	const { mutate } = useDelete(`/orders/${list.orderId}`);
 
 	const handlePageMove = useCallback(() => {
 		navigate(`/detail/${list.item.itemId}`);

--- a/client/src/hooks/useGetWishes.ts
+++ b/client/src/hooks/useGetWishes.ts
@@ -1,0 +1,29 @@
+import { AxiosResponse, AxiosError } from 'axios';
+import { useState } from 'react';
+import { useQuery } from 'react-query';
+import axiosInstance from '../utils/axiosInstance';
+
+// 상세페이지 - 유저의 전체 위시리스트 조회
+export default function useGetWishes<T>(url: string, keyValue: string) {
+	const token = localStorage.getItem('accessToken');
+	// 상태 코드가 403이면 토큰 만료, 재로그인해야 함 (선택사항)
+	const [errorStatus, setErrorStatus] = useState(0);
+
+	// 로그인이 되어있지 않을 때 wishlist 조회 요청 x
+	if (!token) {
+		return { errorStatus };
+	}
+
+	const { isLoading, isError, isSuccess, data, error, refetch } = useQuery<
+		AxiosResponse<T>
+	>([keyValue], () => axiosInstance.get(url), {
+		onError: async (errRes) => {
+			const { response } = errRes as AxiosError;
+			if (response) {
+				setErrorStatus(response.status);
+			}
+		},
+	});
+
+	return { isLoading, isError, isSuccess, data, error, errorStatus, refetch };
+}

--- a/client/src/pages/Detail.tsx
+++ b/client/src/pages/Detail.tsx
@@ -1,22 +1,19 @@
 import styled, { keyframes, css } from 'styled-components';
 import { useLocation, useParams } from 'react-router-dom';
 import { useCallback, useState, useRef, Fragment } from 'react';
-import { useQuery } from 'react-query';
-import { AxiosResponse } from 'axios';
 import { toast } from 'react-toastify';
 import { IoIosArrowBack } from 'react-icons/io';
 import ItemSummary from '../components/ItemSummary/ItemSummary';
 import DetailReviewList from '../components/Lists/DetailReviewList';
 import DetailTalkList from '../components/Lists/DetailTalkList';
 import TalkForm from '../components/Forms/TalkForm';
-import { usePost } from '../hooks/useFetch';
+import { useGet, usePost } from '../hooks/useFetch';
 import {
 	DeliveryInfo,
 	ReturnInfo,
 	ProductInfo,
 } from '../components/Etc/Constants';
 import { LoadingSpinner } from '../components/Etc/LoadingSpinner';
-import axiosInstance from '../utils/axiosInstance';
 import { DetailReviewsData, DetailTalksData } from '../types/note.type';
 import { NutritionFact, ItemShortcutData } from '../types/item.type';
 
@@ -66,10 +63,10 @@ function Detail() {
 	};
 
 	// 상품 상세 조회
-	const { isLoading, isError, data, error } = useQuery<
-		AxiosResponse<DetailItem>
-	>([pathname], () => axiosInstance.get(`/items/${id}`));
-	// const { isLoading, isError, data, error } = useGet(`/items/${id}`, pathname);
+	const { isLoading, isError, data, error } = useGet<DetailItem>(
+		`/items/${id}`,
+		pathname,
+	);
 
 	// 토크 작성
 	const { mutate: talkMu } = usePost(`/talks/${id}`);
@@ -84,7 +81,6 @@ function Detail() {
 		setContent('');
 		setIsTalkOpen(false);
 		setIsDelay(true);
-		// setTimeout(() => setIsTalkOpen(false), 300);
 	}, [content]);
 
 	// 토크 컨텐츠 상태

--- a/client/src/pages/MyPages/NormalOrder.tsx
+++ b/client/src/pages/MyPages/NormalOrder.tsx
@@ -42,7 +42,7 @@ function NormalOrder() {
 	return (
 		<>
 			<ListContainer>
-				{data.pages[0].data.length === 0 ? (
+				{data?.pages[0].data.length === 0 ? (
 					<Message>{NO_ORDER_HISTORY}</Message>
 				) : (
 					data?.pages.map((page, i) => (

--- a/client/src/pages/MyPages/OrderDetail.tsx
+++ b/client/src/pages/MyPages/OrderDetail.tsx
@@ -8,61 +8,60 @@ import CustomerInformation from '../../components/Etc/CustomerInformation';
 import PaymentSummary from '../../components/Etc/PaymentSummary';
 import { useGet } from '../../hooks/useFetch';
 import { LoadingSpinner } from '../../components/Etc/LoadingSpinner';
+import { ERROR_INFORMATION } from '../../components/Etc/Constants';
+import { OrderDetailData } from '../../types/order.type';
 
 // 주문내역 상세조회
 function OrderDetail() {
 	const { pathname } = useLocation();
 	const { id } = useParams();
 
-	const { isLoading, isError, data, error } = useGet(`/orders/${id}`, pathname);
+	const { isLoading, isError, data, error } = useGet<OrderDetailData>(
+		`/orders/${id}`,
+		pathname,
+	);
 
-	if (isLoading) {
+	const lists = !isLoading && data?.data?.data.itemOrders.data;
+	const info = !isLoading && data?.data?.data;
+
+	if (isLoading || !lists || !info) {
 		return <LoadingSpinner />;
 	}
 
-	if (isError) {
-		return <div>Error: {error.message}</div>;
+	if (isError && error instanceof Error) {
+		return <div>{ERROR_INFORMATION}</div>;
 	}
-
-	const lists = !isLoading && data.data.data.itemOrders.data;
-	const info = !isLoading && data.data.data;
-
-	const payData = {
-		totalPrice: info.totalPrice,
-		totalDiscountPrice: info.totalDiscountPrice,
-		expectPrice: info.expectPrice,
-	};
 
 	return (
 		<Box>
 			<LeftContainer>
 				<CustomerInformation payData={info} />
 				<span />
-				<PaymentSummary options payData={payData} />
+				<PaymentSummary payData={info} />
 			</LeftContainer>
 			<RightContainer>
 				<Title className="order">주문 상세 내역</Title>
-				{data &&
-					lists.map((list) => (
-						<OrderDetailList
-							key={list.itemOrderId}
-							itemOrderId={list.itemOrderId} // 개별주문아이디!
-							itemId={list.item.itemId}
-							brand={list.item.brand}
-							thumbnail={list.item.thumbnail}
-							title={list.item.title}
-							quantity={list.quantity}
-							nowPrice={list.item.discountPrice || list.item.price}
-							discountRate={
-								list.item.discountRate === 0 ? '' : list.item.discountRate
-							}
-							beforePrice={list.item.discountPrice ? list.item.price : null}
-							period={list.period}
-							subscription={list.subscription}
-							capacity={list.item.capacity}
-							orderStatus={info.orderStatus}
-						/>
-					))}
+				<ListContainer>
+					{data &&
+						lists.map((list) => (
+							<OrderDetailList
+								key={list.itemOrderId}
+								itemOrderId={list.itemOrderId} // 개별주문아이디!
+								itemId={list.item.itemId}
+								brand={list.item.brand}
+								thumbnail={list.item.thumbnail}
+								title={list.item.title}
+								quantity={list.quantity}
+								nowPrice={list.item.discountPrice || list.item.price}
+								discountRate={list.item.discountRate}
+								beforePrice={list.item.discountPrice && list.item.price}
+								period={list.period}
+								subscription={list.subscription}
+								capacity={list.item.capacity}
+								orderStatus={info.orderStatus}
+							/>
+						))}
+				</ListContainer>
 			</RightContainer>
 		</Box>
 	);
@@ -93,32 +92,41 @@ const LeftContainer = styled.section`
 `;
 
 const RightContainer = styled(LeftContainer)`
+	padding: 0px 0px 40px 0px;
+`;
+
+const ListContainer = styled.div`
 	align-items: center;
 	display: flex;
+	flex-direction: column;
 	justify-content: flex-start;
 	position: relative;
 	padding: 0px;
 	overflow-x: visible;
-	width: 510px;
 	padding-bottom: 30px;
-	overflow-y: scroll;
+	overflow-y: auto;
+	scroll-behavior: smooth;
+
 	::-webkit-scrollbar {
-		display: none;
+		width: 11px;
+	}
+
+	::-webkit-scrollbar-thumb {
+		background-color: rgb(235, 235, 235);
+		border-radius: 10px;
+		background-clip: padding-box;
+		border: 2px solid transparent;
 	}
 `;
 
 const Title = styled.h1`
 	font-size: 20px;
 	font-weight: var(--bold);
-	align-self: flex-start;
-	position: sticky;
+	border-radius: 10px;
 	width: 100%;
-	top: 0px;
-	padding: 70px 0 20px 0;
+	padding: 70px 0 16px 0;
 	background-color: white;
-	&.order {
-		padding-left: 50px;
-	}
+	padding-left: 50px;
 `;
 
 export default React.memo(OrderDetail);

--- a/client/src/pages/MyPages/SubscriptionOrder.tsx
+++ b/client/src/pages/MyPages/SubscriptionOrder.tsx
@@ -43,13 +43,13 @@ function SubscriptionOrder() {
 	return (
 		<>
 			<ListContainer>
-				{data.pages[0].data.length === 0 ? (
+				{data?.pages[0].data.length === 0 ? (
 					<Message>{NO_ORDER_HISTORY}</Message>
 				) : (
 					data?.pages.map((page, i) => (
 						<Fragment key={`page-${i.toString()}`}>
 							{page.data.map((list) => (
-								<OrderList key={list.orderId} list={list} totalPrice />
+								<OrderList key={list.orderId} list={list} />
 							))}
 						</Fragment>
 					))

--- a/client/src/types/button.type.ts
+++ b/client/src/types/button.type.ts
@@ -35,8 +35,8 @@ export interface PriceButtonProps {
 }
 
 export interface WishlistBtnProps {
-	isChecked: boolean | number;
+	isChecked: boolean;
 	itemId: number;
-	setIsChecked?: React.Dispatch<React.SetStateAction<number>>;
+	setIsChecked?: React.Dispatch<React.SetStateAction<boolean>>;
 	setOpenLoginModal?: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/client/src/types/button.type.ts
+++ b/client/src/types/button.type.ts
@@ -37,5 +37,6 @@ export interface PriceButtonProps {
 export interface WishlistBtnProps {
 	isChecked: boolean | number;
 	itemId: number;
-	setIsChecked?: (isChecked: number) => void;
+	setIsChecked?: React.Dispatch<React.SetStateAction<number>>;
+	setOpenLoginModal?: React.Dispatch<React.SetStateAction<boolean>>;
 }

--- a/client/src/types/itemList.type.ts
+++ b/client/src/types/itemList.type.ts
@@ -33,8 +33,8 @@ export interface FetchSearchItems extends GetList {
 	keyword: string;
 }
 
-export interface InfiniteQueryPromise {
-	data: Item[];
+export interface InfiniteQueryPromise<T> {
+	data: T;
 	nextPage: number;
 	isLast: boolean;
 }

--- a/client/src/types/order.type.ts
+++ b/client/src/types/order.type.ts
@@ -1,4 +1,5 @@
 import { ItemShortcutData } from './item.type';
+import { PayData } from './payment.type';
 
 export interface UseGetOrderListProps {
 	pathname: string;
@@ -19,4 +20,25 @@ export interface OrderListData {
 	subscription: boolean;
 	totalItems: number;
 	updatedAt: Date;
+}
+
+export interface OrderDetailListProps {
+	inModal?: boolean;
+	itemOrderId: number;
+	itemId: number;
+	brand: string;
+	thumbnail: string;
+	title: string;
+	quantity: number;
+	nowPrice: number;
+	discountRate: number;
+	beforePrice: number;
+	period: number;
+	subscription: boolean;
+	capacity: number;
+	orderStatus: string;
+}
+
+export interface OrderDetailData {
+	data: PayData;
 }

--- a/client/src/types/order.type.ts
+++ b/client/src/types/order.type.ts
@@ -1,3 +1,5 @@
+import { ItemShortcutData } from './item.type';
+
 export interface UseGetOrderListProps {
 	pathname: string;
 	isSub: boolean;
@@ -6,4 +8,15 @@ export interface UseGetOrderListProps {
 export interface FetchOrderListsProps {
 	pageParam: number;
 	isSub: boolean;
+}
+
+export interface OrderListData {
+	createdAt: Date;
+	expectPrice: number;
+	item: ItemShortcutData;
+	orderId: number;
+	orderStatus: string;
+	subscription: boolean;
+	totalItems: number;
+	updatedAt: Date;
 }


### PR DESCRIPTION
## 이슈와 연결하기

Issue Number: #293 #296 #298 #299 #301

<br>

## 무엇이 추가 되었나요?
### 마이페이지
- 주문내역 조회(일반/정기) 페이지에 타입스크립트 적용하였습니다.
- 주문내역 상세조회 페이지에 타입스크립트 적용하였습니다.

<br><br>

### [로그인하지 않았을 때 유저의 전체 위시리스트 조회 요청 막기](https://github.com/codestates-seb/seb40_main_033/commit/67f1025cd33cf04c129036363857a4394cc868bc)

<img width="527" alt="스크린샷 2023-04-07 오전 1 37 13" src="https://user-images.githubusercontent.com/107875909/230452125-f967a6f2-db99-4334-958a-289966e0ac20.png">

기존 상세페이지에서는 유저의 **로그인 여부와는 상관 없이** 유저의 전체 위시리스트를 조회하는 요청을 보내고 있었습니다.
이로 인해 유저가 로그인을 하지 않고 상세페이지에 접근할 경우 401 에러가 발생하는 것을 콘솔창에서 확인할 수 있었습니다.

해당 에러 해결을 위해 `useGetWishes`라는 요청 Hook을 따로 만들어, 토큰이 있을 때만 요청을 보내도록 구현하였습니다.

<br><br>

### [상세페이지에서 로그인이 필요한 서비스 접근 시 모달 띄우기](https://github.com/codestates-seb/seb40_main_033/commit/17a222812c240bfb492928758138981c3b81ee18)

![로그인권한필요할때모달](https://user-images.githubusercontent.com/107875909/230453007-214ff56d-6c6c-4652-9892-c6f2c11d664a.gif)

로그인 권한이 필요한 서비스인 `찜`, `바로 구매하기`, `장바구니에 담기`를 클릭할 경우 로그인 안내 모달이 나타나도록 구현하였습니다.

로그인 모달은 3초 안에 자동으로 닫히며, `로그인하러 가기`를 클릭할 경우 로그인 페이지로 이동합니다.

<br><br>

### [찜 버튼 2회 이상 클릭 시 요청이 제대로 가지 않는 이슈 수정](https://github.com/codestates-seb/seb40_main_033/pull/300/commits/1fc40e6f4eb5d2464378fa91bc50add7ff146ce8)

**<수정 전>**
![위시버튼고장](https://user-images.githubusercontent.com/107875909/230590810-530b6c4e-a6dd-4f6a-a588-f9ce72d3ad31.gif)

현재 찜한 상태라면(`1`) 찜 해제 요청(`0`)을 보내고, 찜하지 않은 상태(`0`)라면 찜 요청(`1`)을 보내야 하는데,
요청 상태가 변하지 않아 요청이 올바르게 가지 않고 있었습니다.

<br>

**<수정 후>**
![위시버튼말짱](https://user-images.githubusercontent.com/107875909/230590823-c6d6d7ba-258a-4dc1-be93-66ef049cd943.gif)

현재 찜한 상태(`true`)라면 찜 해제 요청(`0`), 찜하지 않은 상태(`false`)라면 찜 요청(`1`)을 보낼 수 있도록
`useEffect` 추가 및 불필요한 `useCallback` 제거하였습니다.


<br><br>

### [toast 알림 화면 밖으로 포커스 이동했을 때 정지되지 않도록 수정](https://github.com/codestates-seb/seb40_main_033/commit/f586438a42c30d7ff6046ada33a57ccc4cf9b458)

**<수정 전>**
![기존toast](https://user-images.githubusercontent.com/107875909/230453174-02ba0224-2aff-4d55-9215-920d0c46cb8f.gif)

기존 toast 알림은 화면 밖으로 포커스 이동 시 알림의 진행 시간이 정지되어 포커스가 다시 돌아올 때까지 알림이 꺼지지 않았습니다.

제 눈에는 이게 묘하게 렉걸린 것처럼 보여서... 🧐
포커스가 화면을 벗어나도 알림의 진행 시간이 멈추지 않도록 옵션을 추가하였습니다!

<br>

**<수정 후>**
![변경후toast](https://user-images.githubusercontent.com/107875909/230453510-2ce3fd17-1b29-4ff5-9079-94609c43f37e.gif)


<br>

## 기타 정보

<br>
